### PR TITLE
test(better-ccusage): fix test to use zai/glm-4.5 instead of deepinfr…

### DIFF
--- a/apps/better-ccusage/src/_pricing-fetcher.ts
+++ b/apps/better-ccusage/src/_pricing-fetcher.ts
@@ -77,7 +77,7 @@ if (import.meta.vitest != null) {
 
 		it('calculates cost for GLM-4.5 model with provider prefix', async () => {
 			using fetcher = new PricingFetcher(true);
-			const pricing = await Result.unwrap(fetcher.getModelPricing('deepinfra/zai-org/GLM-4.5'));
+			const pricing = await Result.unwrap(fetcher.getModelPricing('zai/glm-4.5'));
 			expect(pricing).not.toBeNull();
 			const cost = fetcher.calculateCostFromPricing({
 				input_tokens: 1000,

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -243,7 +243,8 @@ export class LiteLLMPricingFetcher implements Disposable {
 							// Extra priority for zai provider (main GLM models)
 							if (comparison.startsWith('zai/')) {
 								score = 95; // zai provider models get highest priority
-							} else {
+							}
+							else {
 								score = 90; // Contains model name, not air variant
 							}
 						}


### PR DESCRIPTION
…a/zai-org/GLM-4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated pricing retrieval tests to request GLM-4.5 using a provider-prefixed identifier, aligning with current model naming and improving accuracy of pricing resolution checks. Helps prevent regressions around model alias handling.
* **Style**
  * Cleaned up formatting in pricing-matching logic for readability; no functional impact.
* **Chores**
  * No user-facing changes in this release; underlying test and formatting adjustments only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->