### PR TITLE
feat: use local pricing data instead of fetching from LiteLLM

### DIFF
--- a/apps/better-ccusage/src/_macro.ts
+++ b/apps/better-ccusage/src/_macro.ts
@@ -2,7 +2,7 @@ import type { LiteLLMModelPricing } from '@better-ccusage/internal/pricing';
 import process from 'node:process';
 import {
 	createPricingDataset,
-	fetchLiteLLMPricingDataset,
+	loadLocalPricingDataset,
 	filterPricingDataset,
 } from '@better-ccusage/internal/pricing-fetch-utils';
 
@@ -11,16 +11,13 @@ function isClaudeModel(modelName: string, _pricing: LiteLLMModelPricing): boolea
 }
 
 export async function prefetchClaudePricing(): Promise<Record<string, LiteLLMModelPricing>> {
-	if (process.env.OFFLINE === 'true') {
-		return createPricingDataset();
-	}
-
 	try {
-		const dataset = await fetchLiteLLMPricingDataset();
+		// Always use local pricing data
+		const dataset = loadLocalPricingDataset();
 		return filterPricingDataset(dataset, isClaudeModel);
 	}
 	catch (error) {
-		console.warn('Failed to prefetch Claude pricing data, proceeding with empty cache.', error);
+		console.warn('Failed to load local Claude pricing data, proceeding with empty cache.', error);
 		return createPricingDataset();
 	}
 }
@@ -45,16 +42,13 @@ function isGLMModel(modelName: string, _pricing: LiteLLMModelPricing): boolean {
 }
 
 export async function prefetchGLMPricing(): Promise<Record<string, LiteLLMModelPricing>> {
-	if (process.env.OFFLINE === 'true') {
-		return createPricingDataset();
-	}
-
 	try {
-		const dataset = await fetchLiteLLMPricingDataset();
+		// Always use local pricing data
+		const dataset = loadLocalPricingDataset();
 		return filterPricingDataset(dataset, isGLMModel);
 	}
 	catch (error) {
-		console.warn('Failed to prefetch GLM pricing data, proceeding with empty cache.', error);
+		console.warn('Failed to load local GLM pricing data, proceeding with empty cache.', error);
 		return createPricingDataset();
 	}
 }

--- a/apps/codex/src/_macro.ts
+++ b/apps/codex/src/_macro.ts
@@ -2,7 +2,7 @@ import type { LiteLLMModelPricing } from '@better-ccusage/internal/pricing';
 import process from 'node:process';
 import {
 	createPricingDataset,
-	fetchLiteLLMPricingDataset,
+	loadLocalPricingDataset,
 	filterPricingDataset,
 } from '@better-ccusage/internal/pricing-fetch-utils';
 
@@ -19,16 +19,13 @@ function isCodexModel(modelName: string, _pricing: LiteLLMModelPricing): boolean
 }
 
 export async function prefetchCodexPricing(): Promise<Record<string, LiteLLMModelPricing>> {
-	if (process.env.OFFLINE === 'true') {
-		return createPricingDataset();
-	}
-
 	try {
-		const dataset = await fetchLiteLLMPricingDataset();
+		// Always use local pricing data
+		const dataset = loadLocalPricingDataset();
 		return filterPricingDataset(dataset, isCodexModel);
 	}
 	catch (error) {
-		console.warn('Failed to prefetch Codex pricing data, proceeding with empty cache.', error);
+		console.warn('Failed to load local Codex pricing data, proceeding with empty cache.', error);
 		return createPricingDataset();
 	}
 }

--- a/apps/mcp/src/ccusage.ts
+++ b/apps/mcp/src/ccusage.ts
@@ -60,6 +60,8 @@ async function runCcusageCliJson(
 	return executeCliCommand(executable, cliArgs, {
 		// Set Claude path for ccusage
 		CLAUDE_CONFIG_DIR: claudePath,
+		// Force offline mode to prevent network calls to LiteLLM
+		OFFLINE: 'true',
 	});
 }
 

--- a/apps/mcp/src/mcp.ts
+++ b/apps/mcp/src/mcp.ts
@@ -274,7 +274,6 @@ if (import.meta.vitest != null) {
 			});
 
 			it('should call daily tool successfully', async () => {
-				await using fixture = await createFixture({
 					'projects/test-project/session1/usage.jsonl': JSON.stringify({
 						timestamp: '2024-01-01T12:00:00Z',
 						costUSD: 0.001,
@@ -315,7 +314,7 @@ if (import.meta.vitest != null) {
 
 				await client.close();
 				await server.close();
-			});
+			}, 30000);
 
 			it('should call session tool successfully', async () => {
 				await using fixture = await createFixture({


### PR DESCRIPTION
- Add loadLocalPricingDataset() function to load from model_prices_and_context_window.json
- Update all prefetch functions to use local data instead of network calls
- Remove dependency on LiteLLM API calls for pricing data
- Fix MCP test timeout by forcing offline mode
- Increase test timeout for MCP daily tool test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Pricing data now loads from a bundled local dataset across apps for faster startup and consistent offline behavior.
  * Removed reliance on network fetches; features work without internet access.
  * Clearer error messages when local pricing data fails to load, with safe fallbacks.

* **Tests**
  * Increased timeout for the daily tool stdio transport test to improve stability.
  * Adjusted test fixture setup.

* **Chores**
  * Enforced offline mode in CLI execution to prevent network calls.

No user-facing API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->