### PR TITLE
fix(better-ccusage): fix `better-ccusage` shim created by `pnpm link`

### DIFF
--- a/apps/better-ccusage/src/commands/index.ts
+++ b/apps/better-ccusage/src/commands/index.ts
@@ -1,12 +1,13 @@
 import process from 'node:process';
 import { cli } from 'gunshi';
-import { description, name, version } from '../../package.json';
+import packageJson from '../../package.json' with { type: 'json' };
 import { blocksCommand } from './blocks.ts';
 import { dailyCommand } from './daily.ts';
 import { monthlyCommand } from './monthly.ts';
 import { sessionCommand } from './session.ts';
 import { statuslineCommand } from './statusline.ts';
 import { weeklyCommand } from './weekly.ts';
+const { description, name, version } = packageJson;
 
 // Re-export all commands for easy importing
 export { blocksCommand, dailyCommand, monthlyCommand, sessionCommand, statuslineCommand, weeklyCommand };

--- a/apps/better-ccusage/src/logger.ts
+++ b/apps/better-ccusage/src/logger.ts
@@ -9,7 +9,8 @@
 
 import { createLogger, log as internalLog } from '@better-ccusage/internal/logger';
 
-import { name } from '../package.json';
+import packageJson from '../package.json' with { type: 'json' };
+const { name } = packageJson;
 
 /**
  * Application logger instance with package name tag


### PR DESCRIPTION
`pnpm link` allows to make `better-ccusage` to be globally available in system and calling `index.ts` directly, which is useful - allowing to keep globally use editable installation of the package. But the problem is, since `src/index.ts` is using `node` in it's shebang, `better-ccusage` shebang ends up using `node` too, which doesn't allow `import { description, name, version } from '../../package.json';` type of syntax and it fails with error below. Importing `package.json` with import attribute `type` - `json` resolves the issue.

```
node:internal/modules/esm/assert:88
        throw new ERR_IMPORT_ATTRIBUTE_MISSING(url, 'type', validType);
              ^

TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module "file:////better-ccusage/apps/better-ccusage/package.json" needs an import attribute of "type: json"
    at validateAttributes (node:internal/modules/esm/assert:88:15)
    at defaultLoadSync (node:internal/modules/esm/load:164:3)
    at #loadAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:796:12)
    at #loadSync (node:internal/modules/esm/loader:816:49)
    at ModuleLoader.load (node:internal/modules/esm/loader:781:26)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:526:31)
    at #getOrCreateModuleJobAfterResolve (node:internal/modules/esm/loader:577:36)
    at afterResolve (node:internal/modules/esm/loader:625:52)
    at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:631:12)
    at ModuleJob.syncLink (node:internal/modules/esm/module_job:160:33) {
  code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
}

Node.js v24.14.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized how package metadata is loaded internally across the app.  
  * Internal import mechanics were updated for consistency; exports and runtime behavior remain unchanged.  
  * No user-facing changes or functionality impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->