### PR TITLE
test(better-ccusage): make tests pass on Windows (path issues)

### DIFF
--- a/apps/better-ccusage/src/data-loader.ts
+++ b/apps/better-ccusage/src/data-loader.ts
@@ -2951,7 +2951,7 @@ invalid json line
 			expect(result).toHaveLength(2);
 			expect(result.find(s => s.sessionId === 'session123')).toBeTruthy();
 			expect(
-				result.find(s => s.projectPath === 'project1/subfolder'),
+				result.find(s => s.projectPath === path.join('project1', 'subfolder')),
 			).toBeTruthy();
 			expect(result.find(s => s.sessionId === 'session456')).toBeTruthy();
 			expect(result.find(s => s.projectPath === 'project2')).toBeTruthy();
@@ -4936,7 +4936,7 @@ if (import.meta.vitest != null) {
 
 			// Check base directories are included
 			const result1 = results.find(r => r.file.includes('project1'));
-			expect(result1?.baseDir).toContain('path1/projects');
+			expect(result1?.baseDir).toContain(path.join('path1', 'projects'));
 		});
 
 		it('should handle errors gracefully and return empty array for failed paths', async () => {
@@ -4977,7 +4977,7 @@ if (import.meta.vitest != null) {
 			const results = await globUsageFiles(paths);
 
 			expect(results).toHaveLength(3);
-			expect(results.every(r => r.baseDir.includes('path1/projects'))).toBe(true);
+			expect(results.every(r => r.baseDir.includes(path.join('path1', 'projects')))).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
Fixing `better-ccusage` tests to make them also pass on Windows. 

Previously 3 tests were failing due to path issues, see their errors below:

```
 FAIL  src/data-loader.ts > loadSessionData > extracts session info from file paths
AssertionError: expected undefined to be truthy

- Expected:
true

+ Received:
undefined

 ❯ src/data-loader.ts:2955:6
    2953|    expect(
    2954|     result.find(s => s.projectPath === 'project1/subfolder'),
    2955|    ).toBeTruthy();
       |      ^
    2956|    expect(result.find(s => s.sessionId === 'session456')).toBeTruthy();
    2957|    expect(result.find(s => s.projectPath === 'project2')).toBeTruthy();

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  src/data-loader.ts > globUsageFiles > should glob files from multiple paths in parallel with base directories
AssertionError: expected 'C:\Users\xxxx\AppData\Local\Temp\fs…' to contain 'path1/projects'

Expected: "path1/projects"
Received: "C:\Users\xxxx\AppData\Local\Temp\fs-fixture-f6ZNik\path1\projects"

 ❯ src/data-loader.ts:4939:29
    4937|    // Check base directories are included
    4938|    const result1 = results.find(r => r.file.includes('project1'));
    4939|    expect(result1?.baseDir).toContain('path1/projects');
       |                             ^
    4940|   });
    4941|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  src/data-loader.ts > globUsageFiles > should handle multiple files from same base directory
AssertionError: expected false to be true // Object.is equality

- Expected
+ Received

- true
+ false

 ❯ src/data-loader.ts:4980:69
    4978|
    4979|    expect(results).toHaveLength(3);
    4980|    expect(results.every(r => r.baseDir.includes('path1/projects'))).toBe(true);
       |                                                                     ^
    4981|   });
    4982|  });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed | 14 passed (15)
      Tests  3 failed | 286 passed (289)
   Start at  05:20:16
   Duration  8.37s (transform 3.69s, setup 0ms, collect 34.80s, tests 5.12s, environment 3ms, prepare 13.07s)

 ELIFECYCLE  Test failed. See above for more details.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use OS-specific path separators for improved cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->