### PR TITLE
fix: bundle pricing JSON in all packages

### DIFF
--- a/apps/better-ccusage/package.json
+++ b/apps/better-ccusage/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "better-ccusage",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "Enhanced usage analysis tool for Claude Code with multi-provider support",
 	"homepage": "https://github.com/cobra91/better-ccusage#readme",
 	"bugs": {
@@ -30,7 +30,6 @@
 	},
 	"files": [
 		"config-schema.json",
-		"model_prices_and_context_window.json",
 		"dist"
 	],
 	"scripts": {

--- a/apps/better-ccusage/tsdown.config.ts
+++ b/apps/better-ccusage/tsdown.config.ts
@@ -34,5 +34,8 @@ export default defineConfig({
 	define: {
 		'import.meta.vitest': 'undefined',
 	},
-	onSuccess: 'sort-package-json',
+	onSuccess: [
+		'sort-package-json',
+		'node -e "require(\'fs\').copyFileSync(\'../../packages/internal/model_prices_and_context_window.json\',\'dist/model_prices_and_context_window.json\')"',
+	],
 });

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/codex",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Usage analysis tool for OpenAI Codex sessions",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/apps/codex/tsdown.config.ts
+++ b/apps/codex/tsdown.config.ts
@@ -22,5 +22,8 @@ export default defineConfig({
 	define: {
 		'import.meta.vitest': 'undefined',
 	},
-	onSuccess: 'sort-package-json',
+	onSuccess: [
+		'sort-package-json',
+		'node -e "require(\'fs\').copyFileSync(\'../../packages/internal/model_prices_and_context_window.json\',\'dist/model_prices_and_context_window.json\')"',
+	],
 });

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/mcp",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "MCP server implementation for better-ccusage data with multi-provider support",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/apps/mcp/tsdown.config.ts
+++ b/apps/mcp/tsdown.config.ts
@@ -21,5 +21,8 @@ export default defineConfig({
 	define: {
 		'import.meta.vitest': 'undefined',
 	},
-	onSuccess: 'sort-package-json',
+	onSuccess: [
+		'sort-package-json',
+		'node -e "require(\'fs\').copyFileSync(\'../../packages/internal/model_prices_and_context_window.json\',\'dist/model_prices_and_context_window.json\')"',
+	],
 });

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/opencode",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Usage analysis tool for OpenCode AI assistant",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/apps/opencode/tsdown.config.ts
+++ b/apps/opencode/tsdown.config.ts
@@ -12,4 +12,7 @@ export default defineConfig({
 	minify: false,
 	sourcemap: true,
 	external: [],
+	onSuccess: [
+		'node -e "require(\'fs\').copyFileSync(\'../../packages/internal/model_prices_and_context_window.json\',\'dist/model_prices_and_context_window.json\')"',
+	],
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@better-ccusage/docs",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"private": true,
 	"description": "Documentation for better-ccusage",
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "better-ccusage-monorepo",
 	"type": "module",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"private": true,
 	"workspaces": [
 		"apps/*",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@better-ccusage/internal",
 	"type": "module",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"private": true,
 	"description": "Shared internal utilities for better-ccusage toolchain",
 	"exports": {

--- a/packages/internal/src/pricing-fetch-utils.ts
+++ b/packages/internal/src/pricing-fetch-utils.ts
@@ -35,8 +35,10 @@ export function loadLocalPricingDataset(): PricingDataset {
 		const currentModuleDir = dirname(fileURLToPath(import.meta.url));
 
 		const possiblePaths = [
-			// Published package: alongside the bundled file in dist/
+			// Bundled package: alongside the bundled file in dist/
 			join(currentModuleDir, 'model_prices_and_context_window.json'),
+			// Published npm package: one level up from dist/ to package root
+			join(currentModuleDir, '..', 'model_prices_and_context_window.json'),
 			// Development: in the app root directory
 			join(cwd(), 'model_prices_and_context_window.json'),
 		];

--- a/packages/internal/src/pricing-fetch-utils.ts
+++ b/packages/internal/src/pricing-fetch-utils.ts
@@ -37,7 +37,8 @@ export function loadLocalPricingDataset(): PricingDataset {
 		const possiblePaths = [
 			// Bundled package: alongside the bundled file in dist/
 			join(currentModuleDir, 'model_prices_and_context_window.json'),
-			// Published npm package: one level up from dist/ to package root
+			// Development (unbundled): import.meta.url resolves to src/, so
+			// '..' lands on the internal package root where the JSON lives
 			join(currentModuleDir, '..', 'model_prices_and_context_window.json'),
 			// Development: in the app root directory
 			join(cwd(), 'model_prices_and_context_window.json'),

--- a/packages/internal/src/pricing-fetch-utils.ts
+++ b/packages/internal/src/pricing-fetch-utils.ts
@@ -37,8 +37,8 @@ export function loadLocalPricingDataset(): PricingDataset {
 		const possiblePaths = [
 			// Bundled package: alongside the bundled file in dist/
 			join(currentModuleDir, 'model_prices_and_context_window.json'),
-			// Development (unbundled): import.meta.url resolves to src/, so
-			// '..' lands on the internal package root where the JSON lives
+			// Fallback: one level up from dist/ to package root (published
+			// package with JSON at root) or from src/ to internal package (dev)
 			join(currentModuleDir, '..', 'model_prices_and_context_window.json'),
 			// Development: in the app root directory
 			join(cwd(), 'model_prices_and_context_window.json'),

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@better-ccusage/terminal",
 	"type": "module",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"private": true,
 	"description": "Terminal utilities for better-ccusage",
 	"exports": {


### PR DESCRIPTION
## Summary

- `model_prices_and_context_window.json` was missing from `dist/` in published npm packages, causing pricing lookups to fail at runtime
- Added `onSuccess` copy step to all 4 tsdown configs (better-ccusage, codex, mcp, opencode) to automatically copy the JSON into `dist/` during build
- Added fallback path `../model_prices_and_context_window.json` in `pricing-fetch-utils.ts` to check the npm package root when dist/ copy is absent
- Removed redundant `"model_prices_and_context_window.json"` from `better-ccusage` package.json `files` field (now lives in `dist/`)

## Test plan

- [ ] `pnpm install && pnpm run build` in each app — verify `dist/model_prices_and_context_window.json` exists
- [ ] `pnpm dlx better-ccusage@1.3.5 daily` — verify pricing resolves correctly
- [ ] `pnpm dlx @better-ccusage/mcp@1.3.5 -- --help` — verify MCP server starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 1.3.5 across packages.

* **Improvements**
  * Ensure model pricing data is packaged and available in build outputs.
  * Add additional runtime lookup location for model pricing data so apps can find it in more installation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->