### PR TITLE
fix: use rolldown plugin for pricing JSON copy and fix glob on Windows

### DIFF
--- a/apps/better-ccusage/src/data-loader.ts
+++ b/apps/better-ccusage/src/data-loader.ts
@@ -1248,11 +1248,17 @@ export async function loadSessionUsageById(
 ): Promise<{ totalCost: number; entries: UsageData[] } | null> {
 	const claudePaths = getClaudePaths();
 
-	// Find the JSONL file for this session ID
-	// On Windows, replace backslashes from path.join with forward slashes for tinyglobby compatibility
-	const patterns = claudePaths.map(p => path.join(p, 'projects', '**', `${sessionId}.jsonl`).replaceAll('\\', '/'));
-	// Absolute paths are important on Windows; relative paths break when the file is on a different drive.
-	const jsonlFiles = await glob(patterns, { absolute: true });
+	// Find the JSONL file for this session ID.
+	// Use cwd-based glob per path to avoid tinyglobby issues with Windows 8.3
+	// short paths (e.g. C:\Users\DAMLEC~1\...) where absolute glob patterns fail.
+	const relativePattern = `projects/**/${sessionId}.jsonl`;
+	const results = await Promise.all(
+		claudePaths.map(async (p) => {
+			const files = await glob([relativePattern], { cwd: p, absolute: true });
+			return files;
+		}),
+	);
+	const jsonlFiles = results.flat();
 
 	if (jsonlFiles.length === 0) {
 		return null;

--- a/apps/better-ccusage/tsdown.config.ts
+++ b/apps/better-ccusage/tsdown.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsdown';
 import Macros from 'unplugin-macros/rolldown';
+import { copyPricingPlugin } from '../../scripts/copy-pricing-plugin.ts';
 
 export default defineConfig({
 	entry: [
@@ -30,12 +31,9 @@ export default defineConfig({
 		Macros({
 			include: ['src/index.ts', 'src/pricing-fetcher.ts'],
 		}),
+		copyPricingPlugin('better-ccusage'),
 	],
 	define: {
 		'import.meta.vitest': 'undefined',
 	},
-	onSuccess: [
-		'sort-package-json',
-		'node -e "require(\'fs\').copyFileSync(\'../../packages/internal/model_prices_and_context_window.json\',\'dist/model_prices_and_context_window.json\')"',
-	],
 });

--- a/apps/codex/tsdown.config.ts
+++ b/apps/codex/tsdown.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsdown';
 import Macros from 'unplugin-macros/rolldown';
+import { copyPricingPlugin } from '../../scripts/copy-pricing-plugin.ts';
 
 export default defineConfig({
 	entry: ['src/index.ts'],
@@ -18,12 +19,9 @@ export default defineConfig({
 		Macros({
 			include: ['src/index.ts', 'src/pricing.ts'],
 		}),
+		copyPricingPlugin('codex'),
 	],
 	define: {
 		'import.meta.vitest': 'undefined',
 	},
-	onSuccess: [
-		'sort-package-json',
-		'node -e "require(\'fs\').copyFileSync(\'../../packages/internal/model_prices_and_context_window.json\',\'dist/model_prices_and_context_window.json\')"',
-	],
 });

--- a/apps/mcp/tsdown.config.ts
+++ b/apps/mcp/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsdown';
+import { copyPricingPlugin } from '../../scripts/copy-pricing-plugin.ts';
 
 export default defineConfig({
 	entry: ['src/index.ts'],
@@ -21,8 +22,5 @@ export default defineConfig({
 	define: {
 		'import.meta.vitest': 'undefined',
 	},
-	onSuccess: [
-		'sort-package-json',
-		'node -e "require(\'fs\').copyFileSync(\'../../packages/internal/model_prices_and_context_window.json\',\'dist/model_prices_and_context_window.json\')"',
-	],
+	plugins: [copyPricingPlugin('mcp')],
 });

--- a/apps/opencode/tsdown.config.ts
+++ b/apps/opencode/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsdown';
+import { copyPricingPlugin } from '../../scripts/copy-pricing-plugin.ts';
 
 export default defineConfig({
 	entry: [
@@ -12,7 +13,5 @@ export default defineConfig({
 	minify: false,
 	sourcemap: true,
 	external: [],
-	onSuccess: [
-		'node -e "require(\'fs\').copyFileSync(\'../../packages/internal/model_prices_and_context_window.json\',\'dist/model_prices_and_context_window.json\')"',
-	],
+	plugins: [copyPricingPlugin('opencode')],
 });

--- a/scripts/copy-pricing-plugin.ts
+++ b/scripts/copy-pricing-plugin.ts
@@ -1,0 +1,29 @@
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Plugin } from 'rolldown';
+
+const monorepoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const src = resolve(monorepoRoot, 'packages', 'internal', 'model_prices_and_context_window.json');
+
+/**
+ * Rolldown plugin that copies model_prices_and_context_window.json into the
+ * app's dist/ directory after the bundle is written. Runs in-process so it
+ * works reliably on Windows where tsdown's onSuccess shell quoting breaks.
+ */
+export function copyPricingPlugin(appName: string): Plugin {
+	return {
+		name: 'copy-pricing-json',
+		writeBundle() {
+			if (!existsSync(src)) {
+				console.error(`[copy-pricing-json] Source not found: ${src}`);
+				return;
+			}
+
+			const dest = resolve(monorepoRoot, 'apps', appName, 'dist', 'model_prices_and_context_window.json');
+			mkdirSync(dirname(dest), { recursive: true });
+			copyFileSync(src, dest);
+			console.log(`[copy-pricing-json] Copied pricing JSON to ${dest}`);
+		},
+	};
+}

--- a/scripts/copy-pricing-plugin.ts
+++ b/scripts/copy-pricing-plugin.ts
@@ -16,8 +16,7 @@ export function copyPricingPlugin(appName: string): Plugin {
 		name: 'copy-pricing-json',
 		writeBundle() {
 			if (!existsSync(src)) {
-				console.error(`[copy-pricing-json] Source not found: ${src}`);
-				return;
+				throw new Error(`[copy-pricing-json] Source not found: ${src}`);
 			}
 
 			const dest = resolve(monorepoRoot, 'apps', appName, 'dist', 'model_prices_and_context_window.json');


### PR DESCRIPTION
## Summary

- Replace tsdown `onSuccess` shell hook with an in-process rolldown plugin (`copyPricingPlugin`) to copy `model_prices_and_context_window.json` into `dist/` during build. The `onSuccess` approach was unreliable on Windows — the subprocess couldn't find `node`/`npx` in PATH and couldn't handle paths with spaces in shell commands.
- Fix `loadSessionUsageById` to use cwd-based glob patterns instead of absolute paths, which fails on Windows when the user's home directory uses 8.3 short names (e.g. `DAMLEC~1`).

## Test plan

- [x] All 4 apps build successfully with pricing JSON copied to `dist/`
- [x] Full test suite passes: 291/291 better-ccusage, 6/6 codex, 24/24 mcp, 6/6 opencode, 12/12 internal, 33/33 terminal
- [x] Pre-commit hooks pass (lint-staged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build configuration streamlined: Pricing data management now uses a dedicated plugin instead of manual commands across multiple applications.

* **Refactor**
  * Data loading mechanism improved with enhanced file discovery and processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->