### PR TITLE
chore: restore build scripts, fix docs build, and add missing codex dep

### DIFF
--- a/apps/better-ccusage/package.json
+++ b/apps/better-ccusage/package.json
@@ -33,7 +33,14 @@
 		"dist"
 	],
 	"scripts": {
-		"test": "TZ=UTC vitest run"
+		"build": "pnpm run generate:schema && tsdown",
+		"format": "pnpm run lint --fix",
+		"generate:schema": "bun scripts/generate-json-schema.ts",
+		"lint": "eslint --cache .",
+		"prepack": "pnpm run build && clean-pkg-json",
+		"prerelease": "pnpm run lint && pnpm run typecheck && pnpm run build",
+		"test": "TZ=UTC vitest run",
+		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {
 		"@antfu/utils": "catalog:runtime",
@@ -43,7 +50,9 @@
 		"@ryoppippi/eslint-config": "catalog:lint",
 		"@ryoppippi/limo": "catalog:runtime",
 		"@std/async": "catalog:runtime",
+		"@typescript/native-preview": "catalog:types",
 		"ansi-escapes": "catalog:runtime",
+		"clean-pkg-json": "catalog:release",
 		"consola": "catalog:runtime",
 		"es-toolkit": "catalog:runtime",
 		"eslint": "catalog:lint",

--- a/apps/better-ccusage/tsconfig.json
+++ b/apps/better-ccusage/tsconfig.json
@@ -32,6 +32,7 @@
 		"skipLibCheck": true
 	},
 	"exclude": [
-		"dist"
+		"dist",
+		"tsdown.config.ts"
 	]
 }

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -22,12 +22,21 @@
     "dist"
   ],
   "scripts": {
-    "test": "TZ=UTC vitest run"
+    "build": "tsdown",
+    "format": "pnpm run lint --fix",
+    "lint": "eslint --cache .",
+    "prepack": "pnpm run build && clean-pkg-json",
+    "prerelease": "pnpm run lint && pnpm run typecheck && pnpm run build",
+    "test": "TZ=UTC vitest run",
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@better-ccusage/internal": "workspace:*",
+    "@better-ccusage/terminal": "workspace:*",
     "@praha/byethrow": "catalog:runtime",
     "@ryoppippi/eslint-config": "catalog:lint",
+    "@typescript/native-preview": "catalog:types",
+    "clean-pkg-json": "catalog:release",
     "consola": "catalog:runtime",
     "eslint": "catalog:lint",
     "fast-sort": "catalog:runtime",

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -28,7 +28,13 @@
     "dist"
   ],
   "scripts": {
-    "test": "TZ=UTC vitest run"
+    "build": "tsdown",
+    "format": "pnpm run lint --fix",
+    "lint": "eslint --cache .",
+    "prepack": "pnpm run build && clean-pkg-json",
+    "prerelease": "pnpm run lint && pnpm run typecheck && pnpm run build",
+    "test": "TZ=UTC vitest run",
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@better-ccusage/internal": "workspace:*",
@@ -36,7 +42,9 @@
     "@hono/node-server": "catalog:runtime",
     "@modelcontextprotocol/sdk": "catalog:runtime",
     "@ryoppippi/eslint-config": "catalog:lint",
+    "@typescript/native-preview": "catalog:types",
     "better-ccusage": "workspace:*",
+    "clean-pkg-json": "catalog:release",
     "eslint": "catalog:lint",
     "fs-fixture": "catalog:testing",
     "gunshi": "catalog:runtime",

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -30,13 +30,21 @@
     "dist"
   ],
   "scripts": {
-    "test": "TZ=UTC vitest run"
+    "build": "tsdown",
+    "format": "pnpm run lint --fix",
+    "lint": "eslint --cache .",
+    "prepack": "pnpm run build && clean-pkg-json",
+    "prerelease": "pnpm run lint && pnpm run typecheck && pnpm run build",
+    "test": "TZ=UTC vitest run",
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@better-ccusage/internal": "workspace:*",
     "@better-ccusage/terminal": "workspace:*",
     "@praha/byethrow": "catalog:runtime",
     "@ryoppippi/eslint-config": "catalog:lint",
+    "@typescript/native-preview": "catalog:types",
+    "clean-pkg-json": "catalog:release",
     "consola": "catalog:runtime",
     "es-toolkit": "catalog:runtime",
     "eslint": "catalog:lint",

--- a/docs/typedoc.config.ts
+++ b/docs/typedoc.config.ts
@@ -21,6 +21,10 @@ export default {
 	// ref: https://typedoc.org/documents/Options.html
 	entryPoints,
 	tsconfig: './node_modules/better-ccusage/tsconfig.json',
+	exclude: [
+		'**/node_modules/**/tsdown.config.ts',
+		'**/node_modules/**/scripts/**',
+	],
 	out: 'api',
 	plugin: ['typedoc-plugin-markdown', 'typedoc-vitepress-theme'],
 	readme: 'none',

--- a/docs/update-api-index.ts
+++ b/docs/update-api-index.ts
@@ -74,7 +74,7 @@ ${noteText}`;
 }
 
 if (import.meta.main) {
-	const typedocBin = join(import.meta.dirname, '..', 'node_modules', '.bin', 'typedoc');
+	const typedocBin = join(import.meta.dirname, 'node_modules', '.bin', 'typedoc');
 	const typedocConfig = join(import.meta.dirname, 'typedoc.config.ts');
 	await Bun.$`cd ${import.meta.dirname} && ${typedocBin} --excludeInternal --options ${typedocConfig}`;
 	await updateApiIndex();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ catalogs:
     bumpp:
       specifier: ^10.3.2
       version: 10.3.2
+    clean-pkg-json:
+      specifier: ^1.3.0
+      version: 1.4.1
     lint-staged:
       specifier: ^16.2.7
       version: 16.2.7
@@ -232,9 +235,15 @@ importers:
       '@std/async':
         specifier: catalog:runtime
         version: '@jsr/std__async@1.2.0'
+      '@typescript/native-preview':
+        specifier: catalog:types
+        version: 7.0.0-dev.20251201.1
       ansi-escapes:
         specifier: catalog:runtime
         version: 7.2.0
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.4.1
       consola:
         specifier: catalog:runtime
         version: 3.4.2
@@ -307,12 +316,21 @@ importers:
       '@better-ccusage/internal':
         specifier: workspace:*
         version: link:../../packages/internal
+      '@better-ccusage/terminal':
+        specifier: workspace:*
+        version: link:../../packages/terminal
       '@praha/byethrow':
         specifier: catalog:runtime
         version: 0.6.3
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.25)(eslint-plugin-format@1.0.2(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(happy-dom@16.8.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@typescript/native-preview':
+        specifier: catalog:types
+        version: 7.0.0-dev.20251201.1
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.4.1
       consola:
         specifier: catalog:runtime
         version: 3.4.2
@@ -367,9 +385,15 @@ importers:
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.25)(eslint-plugin-format@1.0.2(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(happy-dom@16.8.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@typescript/native-preview':
+        specifier: catalog:types
+        version: 7.0.0-dev.20251201.1
       better-ccusage:
         specifier: workspace:*
         version: link:../better-ccusage
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.4.1
       eslint:
         specifier: catalog:lint
         version: 9.39.1(jiti@2.6.1)
@@ -415,6 +439,12 @@ importers:
       '@ryoppippi/eslint-config':
         specifier: catalog:lint
         version: 0.4.0(@vue/compiler-sfc@3.5.25)(eslint-plugin-format@1.0.2(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(happy-dom@16.8.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@typescript/native-preview':
+        specifier: catalog:types
+        version: 7.0.0-dev.20251201.1
+      clean-pkg-json:
+        specifier: catalog:release
+        version: 1.4.1
       consola:
         specifier: catalog:runtime
         version: 3.4.2
@@ -2603,6 +2633,10 @@ packages:
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  clean-pkg-json@1.4.1:
+    resolution: {integrity: sha512-tKXN+XMFG90t5f5kna9wYPvDeNHmBm/Xx81C5c085cwCOMOrZxaqEyF0G0C3i9nZMFhwX5/2euaDUn1h/f1tuA==}
+    hasBin: true
 
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
@@ -6712,6 +6746,8 @@ snapshots:
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
+
+  clean-pkg-json@1.4.1: {}
 
   clean-regexp@1.0.0:
     dependencies:

--- a/scripts/copy-pricing-plugin.ts
+++ b/scripts/copy-pricing-plugin.ts
@@ -1,7 +1,11 @@
 import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { Plugin } from 'rolldown';
+
+interface RolldownPlugin {
+	name: string;
+	writeBundle(): void;
+}
 
 const monorepoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const src = resolve(monorepoRoot, 'packages', 'internal', 'model_prices_and_context_window.json');
@@ -11,7 +15,7 @@ const src = resolve(monorepoRoot, 'packages', 'internal', 'model_prices_and_cont
  * app's dist/ directory after the bundle is written. Runs in-process so it
  * works reliably on Windows where tsdown's onSuccess shell quoting breaks.
  */
-export function copyPricingPlugin(appName: string): Plugin {
+export function copyPricingPlugin(appName: string): RolldownPlugin {
 	return {
 		name: 'copy-pricing-json',
 		writeBundle() {


### PR DESCRIPTION
## Summary

- Restore `build`, `prepack`, `prerelease`, `format`, `lint`, and `typecheck` scripts in all app `package.json` files (aligned with upstream ryoppippi/ccusage)
- Add `@typescript/native-preview` and `clean-pkg-json` to devDependencies where missing
- Add missing `@better-ccusage/terminal` workspace dependency to codex (was causing unresolved import warning)
- Fix docs build: correct typedoc binary path from root to docs-local `node_modules`, and exclude `tsdown.config.ts` / `scripts/` from typedoc analysis
- Exclude `tsdown.config.ts` from better-ccusage `tsconfig.json` to prevent typedoc import resolution errors

## Test plan

- [x] `pnpm run build` succeeds for all packages (apps + docs)
- [x] Full test suite: 372/372 passed, 0 failures
- [x] Pre-commit hooks pass (lint-staged + sort-package-json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and expanded build/release workflows across multiple apps (build, lint, format, typecheck, prerelease/prepack).
  * Added development tooling to support packaging, linting, formatting, and type checking.

* **Documentation**
  * Updated documentation tooling configuration to exclude build-related config and script files from generated docs and TypeScript compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->