### PR TITLE
feat: add LiteLLM remote pricing fetch with local cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 .eslintcache
 
+# auto-generated declarations
+scripts/copy-pricing-plugin.d.ts
+
 # lsmcp cache
 symbols.db
 

--- a/apps/better-ccusage/package.json
+++ b/apps/better-ccusage/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "better-ccusage",
-	"version": "1.3.5",
+	"version": "1.4.0",
 	"description": "Enhanced usage analysis tool for Claude Code with multi-provider support",
 	"homepage": "https://github.com/cobra91/better-ccusage#readme",
 	"bugs": {

--- a/apps/better-ccusage/src/_pricing-fetcher.ts
+++ b/apps/better-ccusage/src/_pricing-fetcher.ts
@@ -1,18 +1,8 @@
 import type { ModelPricing } from '@better-ccusage/internal/pricing';
 import { PricingFetcher } from '@better-ccusage/internal/pricing';
+import { loadMergedPricing } from '@better-ccusage/internal/remote-pricing';
 import { Result } from '@praha/byethrow';
-import { prefetchAllPricing } from './_macro.ts';
 import { logger } from './logger.ts';
-
-const PREFETCHED_PRICING = prefetchAllPricing();
-
-/**
- * Load all available pricing data.
- * The pricing fetcher's fallback logic (exact/suffix/fuzzy matching) handles all models automatically.
- */
-async function prefetchCcusagePricing(): Promise<Record<string, ModelPricing>> {
-	return PREFETCHED_PRICING;
-}
 
 let _sharedPricingMap: Map<string, ModelPricing> | null = null;
 let _sharedPricingPromise: Promise<Map<string, ModelPricing>> | null = null;
@@ -21,7 +11,7 @@ async function getSharedPricingMap(): Promise<Map<string, ModelPricing>> {
 	if (_sharedPricingPromise == null) {
 		_sharedPricingPromise = (async () => {
 			if (_sharedPricingMap == null) {
-				_sharedPricingMap = new Map(Object.entries(await prefetchCcusagePricing()));
+				_sharedPricingMap = new Map(Object.entries(await loadMergedPricing()));
 			}
 			return _sharedPricingMap;
 		})();
@@ -41,14 +31,14 @@ export function createSharedPricingFetcher(): CcusagePricingFetcher {
 }
 
 /**
- * Extended PricingFetcher pre-configured with offline pricing data from the
- * local pricing database. Uses the shared pre-fetched pricing macro for
- * efficient singleton loading across all instances.
+ * Extended PricingFetcher pre-configured with merged pricing data.
+ * Uses loadMergedPricing() which fetches from LiteLLM at runtime with
+ * local cache (24h TTL) and static JSON fallback.
  */
 export class CcusagePricingFetcher extends PricingFetcher {
 	constructor(options?: ConstructorParameters<typeof PricingFetcher>[0]) {
 		super({
-			offlineLoader: async () => prefetchCcusagePricing(),
+			offlineLoader: loadMergedPricing,
 			logger,
 			...options,
 		});

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/codex",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "Usage analysis tool for OpenAI Codex sessions",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/apps/codex/src/pricing.ts
+++ b/apps/codex/src/pricing.ts
@@ -1,15 +1,35 @@
 import type { ModelPricing as InternalModelPricing } from '@better-ccusage/internal/pricing';
 import type { ModelPricing, PricingSource } from './_types.ts';
+import { loadMergedPricing } from '@better-ccusage/internal/remote-pricing';
 import { PricingFetcher } from '@better-ccusage/internal/pricing';
 import { Result } from '@praha/byethrow';
 import { MILLION } from './_consts.ts';
-import { prefetchCodexPricing } from './_macro.ts' with { type: 'macro' };
 import { logger } from './logger.ts';
 
-const CODEX_PROVIDER_PREFIXES = ['openai/', 'azure/', 'openrouter/openai/'];
+const CODEX_PROVIDER_PREFIXES = ['openai/'];
 const CODEX_MODEL_ALIASES_MAP = new Map<string, string>([
 	['gpt-5-codex', 'gpt-5'],
 ]);
+const CODEX_MODEL_PREFIXES = [
+	'gpt-4', 'gpt-4o', 'gpt-5', 'gpt-5-',
+	'chatgpt-4', 'chatgpt-4o',
+	'o1-', 'o3-', 'o4-',
+];
+
+function isCodexModel(modelName: string): boolean {
+	return CODEX_MODEL_PREFIXES.some(prefix => modelName.startsWith(prefix));
+}
+
+async function loadCodexPricing(): Promise<Record<string, InternalModelPricing>> {
+	const merged = await loadMergedPricing();
+	const filtered: Record<string, InternalModelPricing> = {};
+	for (const [name, pricing] of Object.entries(merged)) {
+		if (isCodexModel(name)) {
+			filtered[name] = pricing;
+		}
+	}
+	return filtered;
+}
 
 /**
  * Convert a per-token cost to its per-million (per M tokens) equivalent.
@@ -29,14 +49,12 @@ export type CodexPricingSourceOptions = {
 	offlineLoader?: () => Promise<Record<string, InternalModelPricing>>;
 };
 
-const PREFETCHED_CODEX_PRICING = prefetchCodexPricing();
-
 export class CodexPricingSource implements PricingSource, Disposable {
 	private readonly fetcher: PricingFetcher;
 
 	constructor(options: CodexPricingSourceOptions = {}) {
 		this.fetcher = new PricingFetcher({
-			offlineLoader: options.offlineLoader ?? (async () => PREFETCHED_CODEX_PRICING),
+			offlineLoader: options.offlineLoader ?? loadCodexPricing,
 			logger,
 			providerPrefixes: CODEX_PROVIDER_PREFIXES,
 		});

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/mcp",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "MCP server implementation for better-ccusage data with multi-provider support",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/opencode",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "Usage analysis tool for OpenCode AI assistant",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/apps/opencode/src/data-loader.ts
+++ b/apps/opencode/src/data-loader.ts
@@ -5,6 +5,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
 import { PricingFetcher } from '@better-ccusage/internal/pricing';
+import { loadMergedPricing } from '@better-ccusage/internal/remote-pricing';
 import { Result } from '@praha/byethrow';
 import { groupBy, sortBy } from 'es-toolkit';
 import { glob } from 'tinyglobby';
@@ -15,31 +16,10 @@ import { logger } from './logger.ts';
 const require = createRequire(import.meta.url);
 
 /**
- * Load pricing data from internal package
- * The JSON file is bundled with the internal package
+ * Load pricing data from LiteLLM (with cache) falling back to local static JSON.
  */
 async function loadPricingData(): Promise<Record<string, ModelPricing>> {
-	try {
-		// Try to load from internal package (works in dev mode)
-		const internalPath = require.resolve('@better-ccusage/internal/package.json');
-		const internalDir = path.dirname(internalPath);
-		const pricingPath = path.join(internalDir, '..', 'model_prices_and_context_window.json');
-		const content = await readFile(pricingPath, 'utf-8');
-		return JSON.parse(content) as Record<string, ModelPricing>;
-	}
-	catch {
-		// Fallback: try loading from better-ccusage dist
-		try {
-			const betterCcusagePath = require.resolve('better-ccusage/package.json');
-			const content = await readFile(path.join(path.dirname(betterCcusagePath), 'model_prices_and_context_window.json'), 'utf-8');
-			return JSON.parse(content) as Record<string, ModelPricing>;
-		}
-		catch {
-			// Last resort: return empty object
-			logger.warn('Could not load pricing data, costs will be $0.00');
-			return {};
-		}
-	}
+	return loadMergedPricing();
 }
 
 /**

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@better-ccusage/docs",
-	"version": "1.3.5",
+	"version": "1.4.0",
 	"private": true,
 	"description": "Documentation for better-ccusage",
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"prepare:git": "git config --local core.hooksPath .githooks",
 		"prerelease": "pnpm run --filter '*' prerelease",
 		"release": "pnpm bumpp -r",
+		"sync-pricing": "tsx scripts/sync-pricing.ts",
 		"test": "pnpm run --filter '*' test",
 		"typecheck": "pnpm run --filter '*' typecheck"
 	},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "better-ccusage-monorepo",
 	"type": "module",
-	"version": "1.3.5",
+	"version": "1.4.0",
 	"private": true,
 	"workspaces": [
 		"apps/*",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,12 +1,13 @@
 {
 	"name": "@better-ccusage/internal",
-	"type": "module",
 	"version": "1.3.5",
 	"private": true,
 	"description": "Shared internal utilities for better-ccusage toolchain",
+	"type": "module",
 	"exports": {
 		"./pricing": "./src/pricing.ts",
 		"./pricing-fetch-utils": "./src/pricing-fetch-utils.ts",
+		"./remote-pricing": "./src/remote-pricing.ts",
 		"./logger": "./src/logger.ts",
 		"./format": "./src/format.ts",
 		"./constants": "./src/constants.ts"

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@better-ccusage/internal",
-	"version": "1.3.5",
+	"version": "1.4.0",
 	"private": true,
 	"description": "Shared internal utilities for better-ccusage toolchain",
 	"type": "module",

--- a/packages/internal/src/pricing-fetch-utils.ts
+++ b/packages/internal/src/pricing-fetch-utils.ts
@@ -112,7 +112,15 @@ export function filterPricingDataset(
  * Throws on network errors or invalid response.
  */
 export async function fetchLiteLLMPricingDataset(): Promise<Record<string, LiteLLMModelPricing>> {
-	const response = await fetch(LITELLM_PRICING_URL);
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 15_000);
+	let response: Response;
+	try {
+		response = await fetch(LITELLM_PRICING_URL, { signal: controller.signal });
+	}
+	finally {
+		clearTimeout(timeout);
+	}
 	if (!response.ok) {
 		throw new Error(`Failed to fetch LiteLLM pricing: ${response.status} ${response.statusText}`);
 	}

--- a/packages/internal/src/pricing-fetch-utils.ts
+++ b/packages/internal/src/pricing-fetch-utils.ts
@@ -1,10 +1,12 @@
-import type { ModelPricing } from './pricing.ts';
+import type { LiteLLMModelPricing, ModelPricing } from './pricing.ts';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { cwd } from 'node:process';
 import { fileURLToPath } from 'node:url';
 import * as v from 'valibot';
 import {
+	LITELLM_PRICING_URL,
+	liteLLMModelPricingSchema,
 	modelPricingSchema,
 } from './pricing.ts';
 
@@ -102,4 +104,34 @@ export function filterPricingDataset(
 		}
 	}
 	return filtered;
+}
+
+/**
+ * Fetch the LiteLLM model pricing database from GitHub and validate each entry.
+ * Returns a dataset of LiteLLMModelPricing entries keyed by model name.
+ * Throws on network errors or invalid response.
+ */
+export async function fetchLiteLLMPricingDataset(): Promise<Record<string, LiteLLMModelPricing>> {
+	const response = await fetch(LITELLM_PRICING_URL);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch LiteLLM pricing: ${response.status} ${response.statusText}`);
+	}
+
+	const rawDataset = (await response.json()) as Record<string, unknown>;
+	const dataset = createPricingDataset() as Record<string, LiteLLMModelPricing>;
+
+	for (const [modelName, modelData] of Object.entries(rawDataset)) {
+		if (modelData == null || typeof modelData !== 'object') {
+			continue;
+		}
+
+		const parsed = v.safeParse(liteLLMModelPricingSchema, modelData);
+		if (!parsed.success) {
+			continue;
+		}
+
+		dataset[modelName] = parsed.output;
+	}
+
+	return dataset;
 }

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -60,6 +60,46 @@ export const modelPricingSchema = v.object({
 
 export type ModelPricing = v.InferOutput<typeof modelPricingSchema>;
 
+/**
+ * LiteLLM pricing URL — the canonical source for model pricing data.
+ * Used by fetchLiteLLMPricingDataset() for runtime fetching.
+ */
+export const LITELLM_PRICING_URL = 'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json';
+
+/**
+ * LiteLLM Model Pricing Schema
+ *
+ * Broader than modelPricingSchema — validates all LiteLLM fields including
+ * provider, mode, supports_*, tiered pricing, etc. Used for fetching and
+ * filtering from the LiteLLM database.
+ */
+export const liteLLMModelPricingSchema = v.object({
+	input_cost_per_token: v.optional(v.number()),
+	output_cost_per_token: v.optional(v.number()),
+	cache_creation_input_token_cost: v.optional(v.number()),
+	cache_read_input_token_cost: v.optional(v.number()),
+	max_tokens: v.optional(v.number()),
+	max_input_tokens: v.optional(v.number()),
+	max_output_tokens: v.optional(v.number()),
+	input_cost_per_token_above_200k_tokens: v.optional(v.number()),
+	output_cost_per_token_above_200k_tokens: v.optional(v.number()),
+	cache_creation_input_token_cost_above_200k_tokens: v.optional(v.number()),
+	cache_read_input_token_cost_above_200k_tokens: v.optional(v.number()),
+	input_cost_per_token_above_128k_tokens: v.optional(v.number()),
+	output_cost_per_token_above_128k_tokens: v.optional(v.number()),
+	tiered_pricing: v.optional(v.array(v.object({
+		input_cost_per_token: v.number(),
+		output_cost_per_token: v.number(),
+		range: v.tuple([v.number(), v.number()]),
+		cache_read_input_token_cost: v.optional(v.number()),
+	}))),
+	// LiteLLM extra fields (used for provider filtering)
+	provider: v.optional(v.string()),
+	mode: v.optional(v.string()),
+});
+
+export type LiteLLMModelPricing = v.InferOutput<typeof liteLLMModelPricingSchema>;
+
 export type PricingLogger = {
 	debug: (...args: unknown[]) => void;
 	error: (...args: unknown[]) => void;

--- a/packages/internal/src/remote-pricing.ts
+++ b/packages/internal/src/remote-pricing.ts
@@ -253,8 +253,13 @@ export async function loadMergedPricing(): Promise<Record<string, ModelPricing>>
 		const remoteData = await fetchFilteredRemotePricing();
 		const merged = mergePricingDatasets(staticData, remoteData);
 
-		// Step 5: Write to cache
-		writeCacheFile(merged);
+		// Step 5: Write to cache (best-effort, never block on failure)
+		try {
+			writeCacheFile(merged);
+		}
+		catch {
+			// Cache write failed (read-only fs, permissions) — still return merged
+		}
 
 		return merged;
 	}

--- a/packages/internal/src/remote-pricing.ts
+++ b/packages/internal/src/remote-pricing.ts
@@ -7,9 +7,8 @@ import {
 	readFileSync,
 	writeFileSync,
 } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join } from 'node:path';
 import process from 'node:process';
-import { Result } from '@praha/byethrow';
 import * as v from 'valibot';
 import {
 	createPricingDataset,
@@ -70,6 +69,8 @@ const STRIP_PROVIDER_PREFIXES = [
 	'vercel_ai_gateway/',
 	'wandb/',
 	'gmi/',
+	'azure/',
+	'vertex_ai/',
 	'openrouter/',
 ];
 
@@ -167,7 +168,7 @@ function readCacheFile(): PricingCache | null {
 		const raw = readFileSync(cachePath, 'utf8');
 		const cache = JSON.parse(raw) as PricingCache;
 
-		if (typeof cache.timestamp !== 'number' || typeof cache.dataset !== 'object') {
+		if (typeof cache.timestamp !== 'number' || typeof cache.dataset !== 'object' || cache.dataset === null) {
 			return null;
 		}
 

--- a/packages/internal/src/remote-pricing.ts
+++ b/packages/internal/src/remote-pricing.ts
@@ -1,0 +1,364 @@
+/// <reference types="vitest" />
+
+import type { LiteLLMModelPricing, ModelPricing } from './pricing.ts';
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { Result } from '@praha/byethrow';
+import * as v from 'valibot';
+import {
+	createPricingDataset,
+	fetchLiteLLMPricingDataset,
+	filterPricingDataset,
+	loadLocalPricingDataset,
+} from './pricing-fetch-utils.ts';
+import { modelPricingSchema } from './pricing.ts';
+
+/**
+ * Cache TTL in milliseconds (24 hours).
+ */
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Provider patterns to keep from LiteLLM.
+ * Models matching any of these prefixes or patterns are retained.
+ * Everything else (Bedrock, Fireworks, Azure, Vertex, GMI, deepinfra, Novita, Cerebras, etc.) is stripped.
+ */
+const RELEVANT_PROVIDER_PATTERNS = [
+	'anthropic/',
+	'anthropic.',
+	'claude-',
+	'openai/',
+	'gpt-',
+	'chatgpt-',
+	'o1-',
+	'o3-',
+	'o4-',
+	'zai/',
+	'z-ai/',
+	'glm-',
+	'minimax/',
+	'minimax.',
+	'MiniMax-',
+	'MiniMaxAI/',
+	'moonshot/',
+	'kimi-',
+	'kat-coder',
+	'kat-dev',
+	'dashscope/',
+	'qwen-',
+	'google/',
+	'gemini-',
+];
+
+/**
+ * Providers to strip from model keys (Bedrock, Fireworks, Azure, Vertex, etc.)
+ */
+const STRIP_PROVIDER_PREFIXES = [
+	'bedrock/',
+	'fireworks_ai/',
+	'baseten/',
+	'deepinfra/',
+	'novita/',
+	'cerebras/',
+	'together_ai/',
+	'vercel_ai_gateway/',
+	'wandb/',
+	'gmi/',
+	'openrouter/',
+];
+
+/**
+ * Check if a model is from a relevant provider.
+ * Matches against model name (key) and provider field from LiteLLM data.
+ */
+export function isRelevantProvider(modelName: string, pricing: LiteLLMModelPricing): boolean {
+	const provider = pricing.provider ?? '';
+
+	// Skip irrelevant deployment platforms
+	for (const prefix of STRIP_PROVIDER_PREFIXES) {
+		if (modelName.startsWith(prefix)) {
+			return false;
+		}
+	}
+
+	// Match against relevant patterns
+	for (const pattern of RELEVANT_PROVIDER_PATTERNS) {
+		if (modelName.startsWith(pattern)) {
+			return true;
+		}
+	}
+
+	// Also match by provider field for bare model names (e.g. "MiniMax-M2.7")
+	const relevantProviders = ['anthropic', 'openai', 'minimax', 'moonshot', 'dashscope', 'google'];
+	if (relevantProviders.includes(provider)) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Fetch LiteLLM pricing data filtered to relevant providers only.
+ */
+async function fetchFilteredRemotePricing(): Promise<Record<string, ModelPricing>> {
+	const litellmDataset = await fetchLiteLLMPricingDataset();
+	const filtered = filterPricingDataset(
+		litellmDataset as unknown as Record<string, ModelPricing>,
+		(modelName, pricing) => isRelevantProvider(modelName, pricing as unknown as LiteLLMModelPricing),
+	);
+
+	// Re-validate through our stricter schema to get clean ModelPricing
+	const dataset = createPricingDataset();
+	for (const [name, pricing] of Object.entries(filtered)) {
+		const parsed = v.safeParse(modelPricingSchema, pricing);
+		if (parsed.success && parsed.output.input_cost_per_token != null) {
+			dataset[name] = parsed.output;
+		}
+	}
+
+	return dataset;
+}
+
+/**
+ * Get the cache directory path.
+ * Uses XDG_CACHE_HOME on Linux/macOS, LOCALAPPDATA on Windows.
+ */
+function getCacheDir(): string {
+	const xdgCache = process.env.XDG_CACHE_HOME;
+	if (xdgCache) {
+		return join(xdgCache, 'better-ccusage');
+	}
+
+	if (process.platform === 'win32') {
+		const localAppData = process.env.LOCALAPPDATA;
+		if (localAppData) {
+			return join(localAppData, 'better-ccusage', 'cache');
+		}
+	}
+
+	return join(process.env.HOME ?? process.env.USERPROFILE ?? '/', '.cache', 'better-ccusage');
+}
+
+function getCachePath(): string {
+	return join(getCacheDir(), 'pricing.json');
+}
+
+type PricingCache = {
+	timestamp: number;
+	dataset: Record<string, ModelPricing>;
+};
+
+/**
+ * Read the cache file. Returns null if missing, expired, or corrupt.
+ */
+function readCacheFile(): PricingCache | null {
+	const cachePath = getCachePath();
+	if (!existsSync(cachePath)) {
+		return null;
+	}
+
+	try {
+		const raw = readFileSync(cachePath, 'utf8');
+		const cache = JSON.parse(raw) as PricingCache;
+
+		if (typeof cache.timestamp !== 'number' || typeof cache.dataset !== 'object') {
+			return null;
+		}
+
+		if (Date.now() - cache.timestamp > CACHE_TTL_MS) {
+			return null;
+		}
+
+		return cache;
+	}
+	catch {
+		return null;
+	}
+}
+
+/**
+ * Write the merged dataset to cache.
+ */
+function writeCacheFile(dataset: Record<string, ModelPricing>): void {
+	const cachePath = getCachePath();
+	const cacheDir = dirname(cachePath);
+
+	mkdirSync(cacheDir, { recursive: true });
+
+	const cache: PricingCache = {
+		timestamp: Date.now(),
+		dataset,
+	};
+
+	writeFileSync(cachePath, JSON.stringify(cache), 'utf8');
+}
+
+/**
+ * Merge remote pricing data into static pricing data.
+ * Static entries are NEVER overwritten — they take priority.
+ * This protects tiered pricing data that only exists in the static JSON.
+ */
+function mergePricingDatasets(
+	staticData: Record<string, ModelPricing>,
+	remoteData: Record<string, ModelPricing>,
+): Record<string, ModelPricing> {
+	const merged = { ...remoteData };
+
+	for (const [name, pricing] of Object.entries(staticData)) {
+		if (pricing.input_cost_per_token != null) {
+			merged[name] = pricing;
+		}
+	}
+
+	return merged;
+}
+
+/**
+ * Load merged pricing data: cache → remote → static fallback.
+ *
+ * Strategy:
+ * 1. Load static dataset (always available, fast)
+ * 2. Check cache file — if fresh (< 24h), merge cache with static
+ * 3. If cache stale/missing and not OFFLINE, fetch LiteLLM, filter, merge
+ * 4. Write merged result to cache
+ * 5. Return merged dataset
+ *
+ * If everything fails (offline + no cache), returns static-only dataset.
+ */
+export async function loadMergedPricing(): Promise<Record<string, ModelPricing>> {
+	// Step 1: Always load static as base
+	const staticData = loadLocalPricingDataset();
+
+	// Step 2: Check cache
+	const cache = readCacheFile();
+	if (cache != null) {
+		const merged = mergePricingDatasets(staticData, cache.dataset);
+		return merged;
+	}
+
+	// Step 3: Skip remote fetch if OFFLINE
+	if (process.env.OFFLINE === 'true') {
+		return staticData;
+	}
+
+	// Step 4: Fetch remote
+	try {
+		const remoteData = await fetchFilteredRemotePricing();
+		const merged = mergePricingDatasets(staticData, remoteData);
+
+		// Step 5: Write to cache
+		writeCacheFile(merged);
+
+		return merged;
+	}
+	catch {
+		// Fallback: return static only
+		return staticData;
+	}
+}
+
+if (import.meta.vitest != null) {
+	describe('isRelevantProvider', () => {
+		it('keeps Claude models', () => {
+			expect(isRelevantProvider('claude-sonnet-4-20250514', { provider: 'anthropic' })).toBe(true);
+			expect(isRelevantProvider('anthropic/claude-sonnet-4-20250514', { provider: 'anthropic' })).toBe(true);
+		});
+
+		it('keeps GLM models', () => {
+			expect(isRelevantProvider('glm-4.5', { provider: undefined })).toBe(true);
+			expect(isRelevantProvider('zai/glm-4.5', { provider: undefined })).toBe(true);
+		});
+
+		it('keeps MiniMax models', () => {
+			expect(isRelevantProvider('MiniMax-M2.7', { provider: 'minimax' })).toBe(true);
+			expect(isRelevantProvider('minimax/minimax-m2.7', { provider: undefined })).toBe(true);
+		});
+
+		it('keeps Moonshot/Kimi models', () => {
+			expect(isRelevantProvider('moonshot/kimi-for-coding', { provider: undefined })).toBe(true);
+			expect(isRelevantProvider('kimi-for-coding', { provider: undefined })).toBe(true);
+		});
+
+		it('keeps OpenAI models', () => {
+			expect(isRelevantProvider('gpt-5', { provider: 'openai' })).toBe(true);
+			expect(isRelevantProvider('o3-mini', { provider: undefined })).toBe(true);
+		});
+
+		it('keeps KAT-Coder models', () => {
+			expect(isRelevantProvider('kat-coder-pro-v1', { provider: undefined })).toBe(true);
+		});
+
+		it('keeps Gemini models', () => {
+			expect(isRelevantProvider('gemini-2.5-pro', { provider: 'google' })).toBe(true);
+			expect(isRelevantProvider('google/gemini-2.5-pro', { provider: undefined })).toBe(true);
+		});
+
+		it('strips Bedrock variants', () => {
+			expect(isRelevantProvider('bedrock/us-east-1/anthropic.claude-sonnet-4', { provider: 'anthropic' })).toBe(false);
+		});
+
+		it('strips Fireworks variants', () => {
+			expect(isRelevantProvider('fireworks_ai/accounts/fireworks/models/minimax-m2', { provider: undefined })).toBe(false);
+		});
+
+		it('strips Azure/Vertex/GMI/deepinfra/Novita variants', () => {
+			expect(isRelevantProvider('azure/openai/gpt-5', { provider: undefined })).toBe(false);
+			expect(isRelevantProvider('vertex_ai/zai-org/glm-4.5', { provider: undefined })).toBe(false);
+			expect(isRelevantProvider('deepinfra/zai-org/GLM-4.5', { provider: undefined })).toBe(false);
+			expect(isRelevantProvider('novita/zai-org/glm-4.7', { provider: undefined })).toBe(false);
+			expect(isRelevantProvider('gmi/zai-org/GLM-4.7-FP8', { provider: undefined })).toBe(false);
+		});
+
+		it('strips openrouter proxy variants', () => {
+			expect(isRelevantProvider('openrouter/anthropic/claude-sonnet-4', { provider: undefined })).toBe(false);
+		});
+	});
+
+	describe('mergePricingDatasets', () => {
+		it('adds new models from remote', () => {
+			const staticData = createPricingDataset();
+			staticData['claude-sonnet-4'] = { input_cost_per_token: 3e-6, output_cost_per_token: 15e-6 };
+
+			const remoteData = createPricingDataset();
+			remoteData['MiniMax-M2.7'] = { input_cost_per_token: 3e-7, output_cost_per_token: 1.2e-6 };
+
+			const merged = mergePricingDatasets(staticData, remoteData);
+			expect(merged['claude-sonnet-4']).toBeDefined();
+			expect(merged['MiniMax-M2.7']).toBeDefined();
+		});
+
+		it('never overwrites static entries', () => {
+			const staticData = createPricingDataset();
+			staticData['claude-sonnet-4'] = { input_cost_per_token: 3e-6, output_cost_per_token: 15e-6, cache_read_input_token_cost: 3e-7 };
+
+			const remoteData = createPricingDataset();
+			remoteData['claude-sonnet-4'] = { input_cost_per_token: 5e-6, output_cost_per_token: 20e-6 };
+
+			const merged = mergePricingDatasets(staticData, remoteData);
+			expect(merged['claude-sonnet-4']?.input_cost_per_token).toBe(3e-6);
+			expect(merged['claude-sonnet-4']?.cache_read_input_token_cost).toBe(3e-7);
+		});
+
+		it('handles empty remote dataset', () => {
+			const staticData = createPricingDataset();
+			staticData['glm-4.5'] = { input_cost_per_token: 6e-7, output_cost_per_token: 2.2e-6 };
+
+			const merged = mergePricingDatasets(staticData, {});
+			expect(Object.keys(merged)).toEqual(['glm-4.5']);
+		});
+
+		it('handles empty static dataset', () => {
+			const remoteData = createPricingDataset();
+			remoteData['MiniMax-M2.7'] = { input_cost_per_token: 3e-7, output_cost_per_token: 1.2e-6 };
+
+			const merged = mergePricingDatasets({}, remoteData);
+			expect(merged['MiniMax-M2.7']).toBeDefined();
+		});
+	});
+}

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@better-ccusage/terminal",
-	"type": "module",
-	"version": "1.3.5",
+	"version": "1.4.0",
 	"private": true,
 	"description": "Terminal utilities for better-ccusage",
+	"type": "module",
 	"exports": {
 		"./table": "./src/table.ts",
 		"./utils": "./src/utils.ts"

--- a/scripts/sync-pricing.ts
+++ b/scripts/sync-pricing.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * sync-pricing.ts — Sync static pricing JSON with LiteLLM remote data.
+ *
+ * Fetches the LiteLLM model pricing database, filters to relevant providers,
+ * and merges new models into the local static JSON file.
+ *
+ * Usage:
+ *   pnpm tsx scripts/sync-pricing.ts [--force] [--dry-run]
+ *
+ * Options:
+ *   --force     Skip the OFFLINE environment variable check
+ *   --dry-run   Preview changes without writing
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { env } from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+// @ts-expect-error — TSX resolves this from source
+import { fetchLiteLLMPricingDataset } from '../packages/internal/src/pricing-fetch-utils.ts';
+// @ts-expect-error — TSX resolves this from source
+import { isRelevantProvider } from '../packages/internal/src/remote-pricing.ts';
+// @ts-expect-error — TSX resolves this from source
+import type { LiteLLMModelPricing } from '../packages/internal/src/pricing.ts';
+
+const args = process.argv.slice(2);
+const isDryRun = args.includes('--dry-run');
+const isForce = args.includes('--force');
+
+const monorepoRoot = resolve(fileURLToPath(import.meta.url), '..');
+const staticJsonPath = resolve(monorepoRoot, 'packages', 'internal', 'model_prices_and_context_window.json');
+
+async function main(): Promise<void> {
+	if (!isForce && env.OFFLINE === 'true') {
+		console.log('[sync-pricing] OFFLINE is set. Use --force to override.');
+		process.exit(1);
+	}
+
+	console.log('[sync-pricing] Fetching LiteLLM pricing database...');
+
+	const litellmDataset = await fetchLiteLLMPricingDataset();
+	console.log(`[sync-pricing] Fetched ${Object.keys(litellmDataset).length} models from LiteLLM.`);
+
+	// Load existing static JSON
+	const staticRaw = readFileSync(staticJsonPath, 'utf8');
+	const staticData = JSON.parse(staticRaw) as Record<string, unknown>;
+
+	// Filter LiteLLM to relevant providers
+	const relevantModels: Record<string, unknown> = {};
+	for (const [name, pricing] of Object.entries(litellmDataset)) {
+		if (isRelevantProvider(name, pricing as LiteLLMModelPricing)) {
+			relevantModels[name] = pricing;
+		}
+	}
+	console.log(`[sync-pricing] ${Object.keys(relevantModels).length} models after provider filter.`);
+
+	// Merge: update existing entries, add new ones
+	let updated = 0;
+	let added = 0;
+
+	for (const [name, pricing] of Object.entries(relevantModels)) {
+		if (name in staticData) {
+			// Update pricing fields only, preserve extra fields (mode, supports_*, etc.)
+			const existing = staticData[name] as Record<string, unknown>;
+			const incoming = pricing as Record<string, unknown>;
+			const merged = { ...existing };
+
+			// Update pricing-related fields
+			for (const key of Object.keys(incoming)) {
+				if (typeof incoming[key] === 'number' || typeof incoming[key] === 'boolean') {
+					merged[key] = incoming[key];
+				}
+			}
+
+			staticData[name] = merged;
+			updated++;
+		}
+		else {
+			// New model — add full entry
+			staticData[name] = pricing;
+			added++;
+		}
+	}
+
+	console.log(`[sync-pricing] ${updated} existing models updated, ${added} new models added.`);
+	console.log(`[sync-pricing] Total models in static JSON: ${Object.keys(staticData).length}`);
+
+	if (isDryRun) {
+		console.log('[sync-pricing] Dry run — no changes written.');
+		return;
+	}
+
+	writeFileSync(staticJsonPath, JSON.stringify(staticData, null, '\t') + '\n');
+	console.log(`[sync-pricing] Written to ${staticJsonPath}`);
+}
+
+main().catch((error) => {
+	console.error('[sync-pricing] Error:', error);
+	process.exit(1);
+});

--- a/scripts/sync-pricing.ts
+++ b/scripts/sync-pricing.ts
@@ -29,7 +29,7 @@ const args = process.argv.slice(2);
 const isDryRun = args.includes('--dry-run');
 const isForce = args.includes('--force');
 
-const monorepoRoot = resolve(fileURLToPath(import.meta.url), '..');
+const monorepoRoot = resolve(fileURLToPath(import.meta.url), '..', '..');
 const staticJsonPath = resolve(monorepoRoot, 'packages', 'internal', 'model_prices_and_context_window.json');
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

- Fetch LiteLLM pricing database at runtime instead of relying solely on bundled static JSON — new models appear automatically without rebuild
- 24h local cache (XDG-compliant path, respects `OFFLINE` env) with static JSON as ultimate fallback
- Provider filter strips irrelevant deployment platforms (Bedrock, Fireworks, Azure, Vertex, GMI, deepinfra, Novita, Cerebras, Openrouter) keeping only Anthropic, OpenAI, Zai/GLM, MiniMax, Moonshot/Kimi, KAT-Coder, Dashscope/Qwen, Google/Gemini
- `sync-pricing.ts` CI script to update static JSON from LiteLLM with `--dry-run` support
- Codex app expanded from GPT-5-only to all OpenAI models (gpt-4*, chatgpt-*, o1-*, o3-*, o4-*)

## Data source

**URL**: `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json` — 2656 models, per-token format, filtered to ~200-300 relevant models at runtime.

## Loading strategy

1. Load static dataset (always available, fast)
2. Check cache file — if fresh (< 24h), merge cache with static
3. If cache stale/missing and not OFFLINE, fetch LiteLLM, filter, merge
4. Static entries never overwritten (protects tiered pricing)

## Test plan

- [x] `pnpm run test` — all 315 tests pass
- [x] `pnpm typecheck` — clean across all packages
- [x] `pnpm run build` — all apps build successfully
- [ ] Manual: `pnpm run start daily` — verify remote fetch + cache works
- [ ] Manual: run twice — second run uses cache (instant)
- [ ] Manual: `OFFLINE=true pnpm run start daily` — static fallback works
- [ ] Manual: `pnpm tsx scripts/sync-pricing.ts --dry-run` — preview static JSON update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime merged pricing from remote datasets and a new CLI to sync local pricing.

* **Refactor**
  * Pricing now loads at runtime with remote+cache merging instead of pre-bundled snapshots.
  * Codex pricing scope narrowed to fewer provider model prefixes.
  * Merging preserves existing static pricing entries.

* **Chores**
  * Added package export for remote pricing and updated .gitignore.

* **Tests**
  * Added unit tests for provider filtering and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->