### PR TITLE
fix(codex): gracefully handle unknown models in CodexPricingSource and normalize custom names

### DIFF
--- a/apps/better-ccusage/package.json
+++ b/apps/better-ccusage/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "better-ccusage",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "Enhanced usage analysis tool for Claude Code with multi-provider support",
 	"homepage": "https://github.com/cobra91/better-ccusage#readme",
 	"bugs": {

--- a/apps/better-ccusage/src/droid-adapter.ts
+++ b/apps/better-ccusage/src/droid-adapter.ts
@@ -229,6 +229,10 @@ export function getDroidPath(): string {
 		return path.resolve(envPath);
 	}
 
+	if (process.env.VITEST != null) {
+		return '';
+	}
+
 	const defaultPath = path.join(USER_HOME_DIR, DEFAULT_DROID_SESSIONS_PATH);
 
 	// Return default path even if it doesn't exist (will be handled by caller)

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/codex",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Usage analysis tool for OpenAI Codex sessions",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/apps/codex/src/pricing.ts
+++ b/apps/codex/src/pricing.ts
@@ -89,7 +89,12 @@ export class CodexPricingSource implements PricingSource, Disposable {
 		}
 
 		if (pricing == null) {
-			throw new Error(`Pricing not found for model ${model}`);
+			logger.warn(`Pricing not found for model ${model}, defaulting to 0`);
+			return {
+				inputCostPerMToken: 0,
+				cachedInputCostPerMToken: 0,
+				outputCostPerMToken: 0,
+			};
 		}
 
 		return {
@@ -117,6 +122,17 @@ if (import.meta.vitest != null) {
 			expect(pricing.inputCostPerMToken).toBeCloseTo(1.25);
 			expect(pricing.outputCostPerMToken).toBeCloseTo(10);
 			expect(pricing.cachedInputCostPerMToken).toBeCloseTo(0.125);
+		});
+
+		it('returns zero costs when model pricing is not found', async () => {
+			using source = new CodexPricingSource({
+				offlineLoader: async () => ({}),
+			});
+
+			const pricing = await source.getPricing('unknown-model');
+			expect(pricing.inputCostPerMToken).toBe(0);
+			expect(pricing.outputCostPerMToken).toBe(0);
+			expect(pricing.cachedInputCostPerMToken).toBe(0);
 		});
 	});
 }

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/mcp",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "MCP server implementation for better-ccusage data with multi-provider support",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-ccusage/opencode",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Usage analysis tool for OpenCode AI assistant",
   "homepage": "https://github.com/cobra91/better-ccusage#readme",
   "bugs": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@better-ccusage/docs",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"private": true,
 	"description": "Documentation for better-ccusage",
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "better-ccusage-monorepo",
 	"type": "module",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"private": true,
 	"workspaces": [
 		"apps/*",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@better-ccusage/internal",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"private": true,
 	"description": "Shared internal utilities for better-ccusage toolchain",
 	"type": "module",

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -242,62 +242,63 @@ export class PricingFetcher implements Disposable {
 		return Result.pipe(
 			this.ensurePricingLoaded(),
 			Result.map((pricing) => {
-				for (const candidate of this.createMatchingCandidates(modelName)) {
-					const direct = pricing.get(candidate);
-					if (direct != null) {
-						return direct;
+				const findBestPricingMatch = (target: string): ModelPricing | null => {
+					// 1. Try direct matching candidates
+					for (const candidate of this.createMatchingCandidates(target)) {
+						const direct = pricing.get(candidate);
+						if (direct != null) {
+							return direct;
+						}
 					}
-				}
+
+					// 2. Try exact model name match
+					for (const [key, value] of pricing) {
+						const comparison = key.toLowerCase();
+						if (comparison === target || comparison.endsWith(`/${target}`)) {
+							return value;
+						}
+					}
+
+					// 3. Try partial fuzzy match
+					let bestMatch = null;
+					let bestMatchScore = 0;
+
+					for (const [key, value] of pricing) {
+						const comparison = key.toLowerCase();
+						let score = 0;
+						if (comparison.includes(target)) {
+							if (comparison.includes(`${target}/`) || comparison.endsWith(`/${target}`)) {
+								score = 100;
+							}
+							else if (comparison.includes(target) && !comparison.includes('air')) {
+								if (comparison.startsWith('zai/')) {
+									score = 95;
+								}
+								else {
+									score = 90;
+								}
+							}
+							else if (comparison.includes(target)) {
+								score = 50;
+							}
+						}
+						else if (target.includes(comparison)) {
+							score = 10;
+						}
+
+						if (score > bestMatchScore) {
+							bestMatch = value;
+							bestMatchScore = score;
+						}
+					}
+
+					return bestMatch;
+				};
 
 				const lower = modelName.toLowerCase();
-
-				// Try exact model name match first (highest priority)
-				for (const [key, value] of pricing) {
-					const comparison = key.toLowerCase();
-					if (comparison === lower || comparison.endsWith(`/${lower}`)) {
-						return value;
-					}
-				}
-
-				// Try partial match but prioritize models that contain the full model name
-				let bestMatch = null;
-				let bestMatchScore = 0;
-
-				for (const [key, value] of pricing) {
-					const comparison = key.toLowerCase();
-
-					// Score matches: exact substring gets higher score
-					let score = 0;
-					if (comparison.includes(lower)) {
-						// Higher score for exact model name without "air" suffix
-						if (comparison.includes(`${lower}/`) || comparison.endsWith(`/${lower}`)) {
-							score = 100; // Exact model name as provider/model
-						}
-						else if (comparison.includes(lower) && !comparison.includes('air')) {
-							// Extra priority for zai provider (main GLM models)
-							if (comparison.startsWith('zai/')) {
-								score = 95; // zai provider models get highest priority
-							}
-							else {
-								score = 90; // Contains model name, not air variant
-							}
-						}
-						else if (comparison.includes(lower)) {
-							score = 50; // Contains model name but might be air variant
-						}
-					}
-					else if (lower.includes(comparison)) {
-						score = 10; // Partial match
-					}
-
-					if (score > bestMatchScore) {
-						bestMatch = value;
-						bestMatchScore = score;
-					}
-				}
-
-				if (bestMatch !== null) {
-					return bestMatch;
+				const firstMatch = findBestPricingMatch(lower);
+				if (firstMatch !== null) {
+					return firstMatch;
 				}
 
 				// If no match is found, try normalizing custom model names (quantization, provider repo, local runs)
@@ -313,67 +314,20 @@ export class PricingFetcher implements Disposable {
 						const cleanParts = parts.filter(p => p !== 'remote' && p !== 'unsloth');
 						if (cleanParts.length > 0) {
 							n = cleanParts[cleanParts.length - 1]!;
-						} else {
+						}
+						else {
 							n = last;
 						}
 					}
-					n = n.replace(/-(?:gguf|claude|opus|abliterated|uncenfull|uncensored|instruct|thinking).*$/i, '');
+					n = n.replace(/-(?:gguf|claude|opus|abliterated|uncenfull|uncensored|instruct|thinking).*$/, '');
 					return n;
 				};
 
 				const normalized = normalizeModelName(modelName);
 				if (normalized !== lower) {
-					// 1. Try matching candidates on normalized
-					for (const candidate of this.createMatchingCandidates(normalized)) {
-						const direct = pricing.get(candidate);
-						if (direct != null) {
-							return direct;
-						}
-					}
-
-					// 2. Try exact model name match on normalized
-					for (const [key, value] of pricing) {
-						const comparison = key.toLowerCase();
-						if (comparison === normalized || comparison.endsWith(`/${normalized}`)) {
-							return value;
-						}
-					}
-
-					// 3. Try fuzzy/partial match on normalized
-					let bestNormalizedMatch = null;
-					let bestNormalizedMatchScore = 0;
-
-					for (const [key, value] of pricing) {
-						const comparison = key.toLowerCase();
-						let score = 0;
-						if (comparison.includes(normalized)) {
-							if (comparison.includes(`${normalized}/`) || comparison.endsWith(`/${normalized}`)) {
-								score = 100;
-							}
-							else if (comparison.includes(normalized) && !comparison.includes('air')) {
-								if (comparison.startsWith('zai/')) {
-									score = 95;
-								}
-								else {
-									score = 90;
-								}
-							}
-							else if (comparison.includes(normalized)) {
-								score = 50;
-							}
-						}
-						else if (normalized.includes(comparison)) {
-							score = 10;
-						}
-
-						if (score > bestNormalizedMatchScore) {
-							bestNormalizedMatch = value;
-							bestNormalizedMatchScore = score;
-						}
-					}
-
-					if (bestNormalizedMatch !== null) {
-						return bestNormalizedMatch;
+					const normalizedMatch = findBestPricingMatch(normalized);
+					if (normalizedMatch !== null) {
+						return normalizedMatch;
 					}
 				}
 

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -301,8 +301,8 @@ export class PricingFetcher implements Disposable {
 					return firstMatch;
 				}
 
-				// If no match is found, try normalizing custom model names (quantization, provider repo, local runs)
-				const normalizeModelName = (name: string): string => {
+				// If no match is found, try normalizing custom model names in two stages
+				const normalizeModelNameStage1 = (name: string): string => {
 					let n = name.toLowerCase();
 					const colonIdx = n.indexOf(':');
 					if (colonIdx !== -1) {
@@ -319,8 +319,24 @@ export class PricingFetcher implements Disposable {
 							n = last;
 						}
 					}
+					// Stage 1: Only strip non-standard quantization, local, and repo/fine-tune noise tags, preserving standard variants
+					n = n.replace(/-(?:gguf|awq|gptq|abliterated|uncenfull|uncensored|f16|fp16|bf16|q\d).*$/, '');
+					return n;
+				};
+
+				const normalized1 = normalizeModelNameStage1(modelName);
+				if (normalized1 !== lower) {
+					const match1 = findBestPricingMatch(normalized1);
+					if (match1 !== null) {
+						return match1;
+					}
+				}
+
+				// Stage 2: If Stage 1 didn't match, try a more aggressive normalization stripping variant tags
+				const normalizeModelNameStage2 = (name1: string): string => {
+					let n = name1;
 					if (n.startsWith('claude')) {
-						// For real Claude models, only strip non-standard local/quantization tags
+						// For real Claude models, only strip non-standard local/quantization tags (already done in Stage 1, but keep safety check)
 						n = n.replace(/-(?:gguf|abliterated|uncenfull|uncensored).*$/, '');
 					}
 					else {
@@ -330,11 +346,11 @@ export class PricingFetcher implements Disposable {
 					return n;
 				};
 
-				const normalized = normalizeModelName(modelName);
-				if (normalized !== lower) {
-					const normalizedMatch = findBestPricingMatch(normalized);
-					if (normalizedMatch !== null) {
-						return normalizedMatch;
+				const normalized2 = normalizeModelNameStage2(normalized1);
+				if (normalized2 !== normalized1) {
+					const match2 = findBestPricingMatch(normalized2);
+					if (match2 !== null) {
+						return match2;
 					}
 				}
 
@@ -1003,6 +1019,29 @@ if (import.meta.vitest != null) {
 			const pricing = await Result.unwrap(fetcher.getModelPricing('remote/claude-3-opus-20240229'));
 			expect(pricing).not.toBeNull();
 			expect(pricing?.input_cost_per_token).toBe(15e-6);
+		});
+
+		it('preserves real variant names like -thinking and -instruct for non-Claude models if they match in the DB', async () => {
+			using fetcher = new PricingFetcher({
+				offlineLoader: async () => ({
+					'moonshot/kimi-k2-thinking': {
+						input_cost_per_token: 1.2e-5,
+						output_cost_per_token: 1.2e-5,
+					},
+					'groq/moonshotai/kimi-k2-instruct': {
+						input_cost_per_token: 1.5e-5,
+						output_cost_per_token: 1.5e-5,
+					},
+				}),
+			});
+
+			const pricingThinking = await Result.unwrap(fetcher.getModelPricing('my-custom-provider/kimi-k2-thinking'));
+			expect(pricingThinking).not.toBeNull();
+			expect(pricingThinking?.input_cost_per_token).toBe(1.2e-5);
+
+			const pricingInstruct = await Result.unwrap(fetcher.getModelPricing('my-custom-provider/kimi-k2-instruct-gguf'));
+			expect(pricingInstruct).not.toBeNull();
+			expect(pricingInstruct?.input_cost_per_token).toBe(1.5e-5);
 		});
 	});
 }

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -300,6 +300,83 @@ export class PricingFetcher implements Disposable {
 					return bestMatch;
 				}
 
+				// If no match is found, try normalizing custom model names (quantization, provider repo, local runs)
+				const normalizeModelName = (name: string): string => {
+					let n = name.toLowerCase();
+					const colonIdx = n.indexOf(':');
+					if (colonIdx !== -1) {
+						n = n.slice(0, colonIdx);
+					}
+					const parts = n.split('/');
+					if (parts.length > 1) {
+						const last = parts[parts.length - 1]!;
+						const cleanParts = parts.filter(p => p !== 'remote' && p !== 'unsloth');
+						if (cleanParts.length > 0) {
+							n = cleanParts[cleanParts.length - 1]!;
+						} else {
+							n = last;
+						}
+					}
+					n = n.replace(/-(?:gguf|claude|opus|abliterated|uncenfull|uncensored|instruct|thinking).*$/i, '');
+					return n;
+				};
+
+				const normalized = normalizeModelName(modelName);
+				if (normalized !== lower) {
+					// 1. Try matching candidates on normalized
+					for (const candidate of this.createMatchingCandidates(normalized)) {
+						const direct = pricing.get(candidate);
+						if (direct != null) {
+							return direct;
+						}
+					}
+
+					// 2. Try exact model name match on normalized
+					for (const [key, value] of pricing) {
+						const comparison = key.toLowerCase();
+						if (comparison === normalized || comparison.endsWith(`/${normalized}`)) {
+							return value;
+						}
+					}
+
+					// 3. Try fuzzy/partial match on normalized
+					let bestNormalizedMatch = null;
+					let bestNormalizedMatchScore = 0;
+
+					for (const [key, value] of pricing) {
+						const comparison = key.toLowerCase();
+						let score = 0;
+						if (comparison.includes(normalized)) {
+							if (comparison.includes(`${normalized}/`) || comparison.endsWith(`/${normalized}`)) {
+								score = 100;
+							}
+							else if (comparison.includes(normalized) && !comparison.includes('air')) {
+								if (comparison.startsWith('zai/')) {
+									score = 95;
+								}
+								else {
+									score = 90;
+								}
+							}
+							else if (comparison.includes(normalized)) {
+								score = 50;
+							}
+						}
+						else if (normalized.includes(comparison)) {
+							score = 10;
+						}
+
+						if (score > bestNormalizedMatchScore) {
+							bestNormalizedMatch = value;
+							bestNormalizedMatchScore = score;
+						}
+					}
+
+					if (bestNormalizedMatch !== null) {
+						return bestNormalizedMatch;
+					}
+				}
+
 				return null;
 			}),
 		);
@@ -925,6 +1002,31 @@ if (import.meta.vitest != null) {
 
 			const expectedCost = (50000 * 1e-6) + (10000 * 2e-6) + (5000 * 1e-7);
 			expect(cost).toBeCloseTo(expectedCost);
+		});
+
+		it('normalizes custom model names to match standard database models in getModelPricing', async () => {
+			using fetcher = new PricingFetcher({
+				offlineLoader: async () => ({
+					'dashscope/qwen3.6-35b-a3b': {
+						input_cost_per_token: 0.35e-6,
+						output_cost_per_token: 1.4e-6,
+					},
+				}),
+			});
+
+			const customModels = [
+				'nutboy02/Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-uncenfull:Q2_K_MTX',
+				'unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ2_M',
+				'remote/unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ2_M',
+				'remote/Qwen3.6-35B-A3B',
+			];
+
+			for (const model of customModels) {
+				const pricing = await Result.unwrap(fetcher.getModelPricing(model));
+				expect(pricing).not.toBeNull();
+				expect(pricing?.input_cost_per_token).toBe(0.35e-6);
+				expect(pricing?.output_cost_per_token).toBe(1.4e-6);
+			}
 		});
 	});
 }

--- a/packages/internal/src/pricing.ts
+++ b/packages/internal/src/pricing.ts
@@ -319,7 +319,14 @@ export class PricingFetcher implements Disposable {
 							n = last;
 						}
 					}
-					n = n.replace(/-(?:gguf|claude|opus|abliterated|uncenfull|uncensored|instruct|thinking).*$/, '');
+					if (n.startsWith('claude')) {
+						// For real Claude models, only strip non-standard local/quantization tags
+						n = n.replace(/-(?:gguf|abliterated|uncenfull|uncensored).*$/, '');
+					}
+					else {
+						// For non-Claude models (e.g. Qwen/Llama fine-tunes), strip vendor/quantization suffixes
+						n = n.replace(/-(?:gguf|claude|opus|abliterated|uncenfull|uncensored|instruct|thinking).*$/, '');
+					}
 					return n;
 				};
 
@@ -981,6 +988,21 @@ if (import.meta.vitest != null) {
 				expect(pricing?.input_cost_per_token).toBe(0.35e-6);
 				expect(pricing?.output_cost_per_token).toBe(1.4e-6);
 			}
+		});
+
+		it('preserves real model variant names when they are prefixed', async () => {
+			using fetcher = new PricingFetcher({
+				offlineLoader: async () => ({
+					'claude-3-opus-20240229': {
+						input_cost_per_token: 15e-6,
+						output_cost_per_token: 75e-6,
+					},
+				}),
+			});
+
+			const pricing = await Result.unwrap(fetcher.getModelPricing('remote/claude-3-opus-20240229'));
+			expect(pricing).not.toBeNull();
+			expect(pricing?.input_cost_per_token).toBe(15e-6);
 		});
 	});
 }

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@better-ccusage/terminal",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"private": true,
 	"description": "Terminal utilities for better-ccusage",
 	"type": "module",


### PR DESCRIPTION
# 🛠️ Graceful Pricing Fallback & Custom Model Name Normalization

This PR resolves a critical issue where the Codex tool crashed when encountering local or custom model names (not present in the LiteLLM/Dashscope database) in session logs. It also introduces automatic name normalization and test isolation improvements, and bumps the monorepo to **v1.4.3**.

Closes #37.

---

## 🚀 Key Improvements

### 1. 🛡️ Graceful Pricing Fallback (Codex)
* **Problem**: When a model's pricing is not found in the database, `CodexPricingSource` raised a hard `Error: Pricing not found for model ...` and crashed the execution.
* **Solution**: Instead of crashing, it now logs a clean warning (`logger.warn`) and defaults all pricing parameters (input, output, cache read) to `0` USD. This matches the behavior of the main `better-ccusage` package and allows the report to compile cleanly.

### 2. 🧠 Custom Model Name Normalization (Pricing Fetcher)
* **Problem**: Developers running custom local models (e.g. quantized models or custom fine-tunes via Ollama/Llama.cpp) use long names containing quantizations or custom repository prefixes (e.g. `nutboy02/Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-uncenfull:Q2_K_MTX`).
* **Solution**: `PricingFetcher.getModelPricing` now includes a custom fallback normalizer that cleans up the model name if a direct match isn't found:
  * Strips publisher/repository/deployment prefixes (e.g. `nutboy02/` or `unsloth/`).
  * Strips format/quantization suffixes (e.g. `:Q2_K_MTX` or `:UD-IQ2_M`).
  * Strips format metadata (e.g. `-GGUF`, `-Claude-...`, `-abliterated`, etc.).
  * Effectively normalizes custom formats to the base model name (e.g., `qwen3.6-35b-a3b`).

### 3. 🧪 Test Isolation (Droid Adapter)
* **Problem**: `getDroidPath` checked the host's actual environment / home directory for Droid sessions, which caused `data-loader.ts` unit tests to fail on developer machines with active Droid session files.
* **Solution**: Restored test isolation by returning an empty path from `getDroidPath` when running under `process.env.VITEST`.

---

## 📦 Version Bump
* Consistently bumped all `package.json` configurations in the monorepo to **v1.4.3** using `pnpm release` (which wraps `bumpp -r`).

---

## 🧪 Verification & Quality Control
* **Unit Tests**: Created new unit tests verifying the fallback matching and name normalization under `packages/internal` and `apps/codex`.
* **Test Run**: All **399 unit tests** pass successfully.
* **Build**: Successfully rebuilt all monorepo applications (`better-ccusage`, `codex`, `opencode`).
* **Linting & Formatting**: Clean run of ESLint and Prettier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful handling when model pricing is missing—returns zero cost instead of failing.
  * Improved model-name matching so custom formats and variant suffixes map correctly to pricing records.

* **Chores**
  * Version bump to 1.4.3 across packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cobra91/better-ccusage/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->