### PR TITLE
feat: integrate ZCode usage source + fix terminal column rendering

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2025 ryoppippi
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/better-ccusage/README.md
+++ b/apps/better-ccusage/README.md
@@ -17,7 +17,7 @@
     <img src="https://cdn.jsdelivr.net/gh/cobra91/better-ccusage@main/docs/public/screenshot.png">
 </div>
 
-> Analyze your Claude Code or Droid token usage and costs from local JSONL files with multi-provider support — incredibly fast and informative!
+> Analyze your Claude Code, Droid, or ZCode token usage and costs from local JSONL/SQLite files with multi-provider support — incredibly fast and informative!
 
 ## About better-ccusage
 
@@ -35,9 +35,9 @@ better-ccusage maintains full compatibility with ccusage while adding comprehens
 
 ## better-ccusage Family
 
-### 📊 [better-ccusage](https://www.npmjs.com/package/better-ccusage) - Enhanced Claude Code/Droid Usage Analyzer with Multi-Provider Support
+### 📊 [better-ccusage](https://www.npmjs.com/package/better-ccusage) - Enhanced Claude Code/Droid/ZCode Usage Analyzer with Multi-Provider Support
 
-The main CLI tool for analyzing Claude Code/Droid/OpenCode usage from local JSONL files with support for multiple AI providers including Anthropic, Zai, and all GLM models (including GLM-5-Turbo), kat-coder models. Track daily, weekly, monthly, and session-based usage with beautiful tables and live monitoring.
+The main CLI tool for analyzing Claude Code, Droid, and ZCode usage from local JSONL/SQLite files with support for multiple AI providers including Anthropic, Zai, and all GLM models (including GLM-5-Turbo, GLM-5.2), kat-coder models. Track daily, weekly, monthly, and session-based usage with beautiful tables and live monitoring. ZCode usage is read directly from its SQLite database (`~/.zcode/cli/db/db.sqlite`), so no manual export is needed.
 
 ### 🤖 [@better-ccusage/codex](https://www.npmjs.com/package/@better-ccusage/codex) - OpenAI Codex Usage Analyzer
 
@@ -227,6 +227,7 @@ better-ccusage extends the original ccusage functionality with automatic support
 | Original ccusage Features        | ✅      | ✅             |
 | Show prompt usage for Coding     | ❌      | ✅             |
 | Droid usage                      | ❌      | ✅             |
+| ZCode usage                      | ❌      | ✅             |
 
 ## Star History
 

--- a/apps/better-ccusage/model_prices_and_context_window.json
+++ b/apps/better-ccusage/model_prices_and_context_window.json
@@ -6717,9 +6717,9 @@
 	"zai/glm-5.2": {
 		"input_cost_per_token": 1.4e-6,
 		"provider": "zai",
-		"max_input_tokens": 204800,
+		"max_input_tokens": 1000000,
 		"max_output_tokens": 131072,
-		"max_tokens": 204800,
+		"max_tokens": 1000000,
 		"mode": "chat",
 		"output_cost_per_token": 4.4e-6,
 		"cache_creation_input_token_cost": 0,

--- a/apps/better-ccusage/model_prices_and_context_window.json
+++ b/apps/better-ccusage/model_prices_and_context_window.json
@@ -6714,6 +6714,20 @@
 		"supports_tool_choice": true,
 		"supports_vision": false
 	},
+	"zai/glm-5.2": {
+		"input_cost_per_token": 1.4e-6,
+		"provider": "zai",
+		"max_input_tokens": 204800,
+		"max_output_tokens": 131072,
+		"max_tokens": 204800,
+		"mode": "chat",
+		"output_cost_per_token": 4.4e-6,
+		"cache_creation_input_token_cost": 0,
+		"cache_read_input_token_cost": 2.6e-7,
+		"supports_function_calling": true,
+		"supports_tool_choice": true,
+		"supports_vision": false
+	},
 	"zai/glm-5-turbo": {
 		"input_cost_per_token": 0.0000012,
 		"provider": "zai",

--- a/apps/better-ccusage/package.json
+++ b/apps/better-ccusage/package.json
@@ -77,7 +77,7 @@
 		"xdg-basedir": "catalog:runtime"
 	},
 	"engines": {
-		"node": ">=20.19.4"
+		"node": ">=22.13.0"
 	},
 	"publishConfig": {
 		"bin": {

--- a/apps/better-ccusage/src/_consts.ts
+++ b/apps/better-ccusage/src/_consts.ts
@@ -75,6 +75,23 @@ export const DROID_SESSIONS_DIR_ENV = 'DROID_SESSIONS_DIR';
 export const DEFAULT_DROID_SESSIONS_PATH = `.factory/sessions`;
 
 /**
+ * Environment variable for overriding the ZCode home directory.
+ * When set, the usage database is resolved relative to it.
+ */
+export const ZCODE_HOME_ENV = 'ZCODE_HOME';
+
+/**
+ * Default ZCode home directory: `~/.zcode` (Windows: `C:\Users\<user>\.zcode`).
+ */
+export const DEFAULT_ZCODE_HOME_PATH = '.zcode';
+
+/**
+ * Subpath of the SQLite database that stores ZCode model usage, relative to
+ * the ZCode home directory.
+ */
+export const DEFAULT_ZCODE_DB_SUBPATH = path.join('cli', 'db', 'db.sqlite');
+
+/**
  * Claude projects directory name within the data directory
  * Contains subdirectories for each project with usage data
  */

--- a/apps/better-ccusage/src/_types.ts
+++ b/apps/better-ccusage/src/_types.ts
@@ -80,7 +80,15 @@ export const projectPathSchema = v.pipe(
 
 export const sourceSchema = v.pipe(
 	v.string(),
-	v.picklist(['claude/droid', 'claude', 'droid']),
+	v.picklist([
+		'claude/droid/zcode',
+		'claude/droid',
+		'claude/zcode',
+		'droid/zcode',
+		'claude',
+		'droid',
+		'zcode',
+	]),
 	v.brand('Source'),
 );
 

--- a/apps/better-ccusage/src/data-loader.ts
+++ b/apps/better-ccusage/src/data-loader.ts
@@ -69,6 +69,7 @@ import {
 import { unreachable } from './_utils.ts';
 import { getDroidPath, processDroidSessions } from './droid-adapter.ts';
 import { logger } from './logger.ts';
+import { getZcodeDbPath, processZcodeSessions } from './zcode-adapter.ts';
 
 /**
  * Get Claude data directories to search for usage data
@@ -558,6 +559,34 @@ export function createUniqueHash(data: UsageData): string | null {
 }
 
 /**
+ * Build a combined source label from the set of tool sources present in a group.
+ *
+ * Sources are joined with '/' in a stable canonical order (claude, droid, zcode)
+ * so grouped rows surface every contributing tool. Inputs may already be
+ * combined labels (e.g. `claude/droid` from a daily rollup); those are split
+ * first so the canonical ordering is preserved. An empty set defaults to
+ * 'claude' for backward compatibility with Claude-only data.
+ */
+const SOURCE_ORDER = ['claude', 'droid', 'zcode'] as const;
+
+function combineSources(sources: Set<string | undefined>): string {
+	const atoms = new Set<string>();
+	for (const source of sources) {
+		if (source == null) {
+			continue;
+		}
+		for (const part of source.split('/')) {
+			atoms.add(part);
+		}
+	}
+	const present = SOURCE_ORDER.filter(ordered => atoms.has(ordered));
+	if (present.length === 0) {
+		return createSource('claude');
+	}
+	return createSource(present.join('/'));
+}
+
+/**
  * Extract the earliest timestamp from a JSONL file
  * Scans through the file until it finds a valid timestamp
  */
@@ -783,7 +812,23 @@ export async function loadDailyUsageData(
 		}
 	}
 
-	if (fileList.length === 0 && droidEntries.length === 0) {
+	// Also load zcode usage from its SQLite database if available
+	const zcodeDbPath = getZcodeDbPath();
+	logger.debug(`ZCode database path: ${zcodeDbPath}`);
+	let zcodeEntries: UsageData[] = [];
+	if (zcodeDbPath === '') {
+		logger.debug('ZCode database path is empty');
+	}
+	else {
+		try {
+			zcodeEntries = await processZcodeSessions(zcodeDbPath, options);
+		}
+		catch (error) {
+			logger.warn(`Failed to load zcode sessions: ${String(error)}`);
+		}
+	}
+
+	if (fileList.length === 0 && droidEntries.length === 0 && zcodeEntries.length === 0) {
 		return [];
 	}
 
@@ -891,6 +936,31 @@ export async function loadDailyUsageData(
 		});
 	}
 
+	// Add zcode entries to the collection
+	for (const zcodeData of zcodeEntries) {
+		zcodeData.source ??= createSource('zcode');
+
+		// Check for duplicate message + request ID combination
+		const uniqueHash = createUniqueHash(zcodeData);
+		if (isDuplicateEntry(uniqueHash, processedHashes)) {
+			continue;
+		}
+		markAsProcessed(uniqueHash, processedHashes);
+
+		const date = formatDate(zcodeData.timestamp, options?.timezone, DEFAULT_LOCALE);
+		const cost = fetcher == null
+			? zcodeData.costUSD ?? 0
+			: await calculateCostForEntry(zcodeData, mode, fetcher);
+
+		allEntries.push({
+			data: zcodeData,
+			date,
+			cost,
+			model: zcodeData.message.model,
+			project: zcodeData.cwd ?? path.join('zcode', 'unknown'),
+		});
+	}
+
 	// Group by date, optionally including project
 	// This will combine Claude and droid entries from the same date
 	// Automatically enable project grouping when project filter is specified
@@ -913,25 +983,11 @@ export async function loadDailyUsageData(
 			const date = parts[0] ?? groupKey;
 			const project = parts.length > 1 ? parts[1] : undefined;
 
-			// Determine combined source from all entries in this group
+			// Determine combined source from all entries in this group.
+			// Sources are joined with '/' in a stable order (claude, droid, zcode)
+			// so grouped rows surface every contributing tool.
 			const sources = new Set(entries.map(entry => entry.data.source).filter(Boolean));
-			const claudeSource = createSource('claude');
-			const droidSource = createSource('droid');
-			const claudeDroidSource = createSource('claude/droid');
-			let combinedSource: string;
-			// If no valid sources found, default to 'claude'
-			if (sources.size === 0) {
-				combinedSource = claudeSource;
-			}
-			else if (sources.has(claudeSource) && sources.has(droidSource)) {
-				combinedSource = claudeDroidSource;
-			}
-			else if (sources.has(droidSource)) {
-				combinedSource = droidSource;
-			}
-			else {
-				combinedSource = claudeSource;
-			}
+			const combinedSource = combineSources(sources);
 
 			// Aggregate by model first
 			const modelAggregates = aggregateByModel(
@@ -1007,7 +1063,23 @@ export async function loadSessionData(
 		}
 	}
 
-	if (filesWithBase.length === 0 && droidEntries.length === 0) {
+	// Also load zcode usage from its SQLite database if available
+	const zcodeDbPath = getZcodeDbPath();
+	logger.debug(`ZCode database path: ${zcodeDbPath}`);
+	let zcodeEntries: UsageData[] = [];
+	if (zcodeDbPath === '') {
+		logger.debug('ZCode database path is empty');
+	}
+	else {
+		try {
+			zcodeEntries = await processZcodeSessions(zcodeDbPath, options);
+		}
+		catch (error) {
+			logger.warn(`Failed to load zcode sessions: ${String(error)}`);
+		}
+	}
+
+	if (filesWithBase.length === 0 && droidEntries.length === 0 && zcodeEntries.length === 0) {
 		return [];
 	}
 
@@ -1123,6 +1195,26 @@ export async function loadSessionData(
 			cost,
 			timestamp: droidData.timestamp,
 			model: droidData.message.model,
+		});
+	}
+
+	// Add zcode entries to the collection
+	for (const zcodeData of zcodeEntries) {
+		zcodeData.source ??= createSource('zcode');
+
+		const sessionKey = path.join('zcode', zcodeData.sessionId ?? 'unknown-session');
+		const cost = fetcher == null
+			? zcodeData.costUSD ?? 0
+			: await calculateCostForEntry(zcodeData, mode, fetcher);
+
+		allEntries.push({
+			data: zcodeData,
+			sessionKey,
+			sessionId: zcodeData.sessionId ?? 'unknown-session',
+			projectPath: zcodeData.cwd ?? path.join('zcode', 'unknown'),
+			cost,
+			timestamp: zcodeData.timestamp,
+			model: zcodeData.message.model,
 		});
 	}
 
@@ -1359,26 +1451,11 @@ export async function loadBucketUsageData(
 			}
 		}
 
-		// Determine combined source from all daily entries in this group
+		// Determine combined source from all daily entries in this group.
+		// Daily entries may already carry combined labels (e.g. 'claude/droid');
+		// combineSources splits and re-canonicalizes them.
 		const sources = new Set(dailyEntries.map(entry => entry.source).filter(Boolean));
-		const claudeSource = createSource('claude');
-		const droidSource = createSource('droid');
-		const claudeDroidSource = createSource('claude/droid');
-		let combinedSource: string;
-		// If no valid sources found, default to 'claude'
-		if (sources.size === 0) {
-			combinedSource = claudeSource;
-		}
-		// Check for mixed sources including combined sources
-		else if (sources.has(claudeDroidSource) || (sources.has(claudeSource) && sources.has(droidSource))) {
-			combinedSource = claudeDroidSource;
-		}
-		else if (sources.has(droidSource)) {
-			combinedSource = droidSource;
-		}
-		else {
-			combinedSource = claudeSource;
-		}
+		const combinedSource = combineSources(sources);
 
 		// Calculate totals from daily entries
 		let totalInputTokens = 0;
@@ -1650,8 +1727,39 @@ export async function loadSessionBlockData(
 		}
 	}
 
-	// Combine Claude and droid entries
-	const combinedEntries = [...allEntries, ...droidEntries];
+	// Also load zcode usage from its SQLite database if available
+	const zcodeDbPath = getZcodeDbPath();
+	logger.debug(`ZCode database path for blocks: ${zcodeDbPath}`);
+	let zcodeEntries: LoadedUsageEntry[] = [];
+	if (zcodeDbPath === '') {
+		logger.debug('ZCode database path for blocks is empty');
+	}
+	else {
+		try {
+			const rawZcodeEntries = await processZcodeSessions(zcodeDbPath, options);
+			// Convert zcode entries to LoadedUsageEntry format with Date timestamps
+			zcodeEntries = rawZcodeEntries.map((entry): LoadedUsageEntry => ({
+				timestamp: new Date(entry.timestamp),
+				usage: {
+					inputTokens: entry.message.usage.input_tokens,
+					outputTokens: entry.message.usage.output_tokens,
+					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+				},
+				costUSD: entry.costUSD ?? 0,
+				model: entry.message.model ?? 'unknown',
+				version: entry.version ?? undefined,
+				usageLimitResetTime: undefined,
+				source: entry.source ?? 'zcode',
+			}));
+		}
+		catch (error) {
+			logger.warn(`Failed to load zcode sessions for blocks: ${String(error)}`);
+		}
+	}
+
+	// Combine Claude, droid, and zcode entries
+	const combinedEntries = [...allEntries, ...droidEntries, ...zcodeEntries];
 
 	// Identify session blocks
 	const blocks = identifySessionBlocks(combinedEntries, allUserMessages, options?.sessionDurationHours);

--- a/apps/better-ccusage/src/zcode-adapter.ts
+++ b/apps/better-ccusage/src/zcode-adapter.ts
@@ -1,0 +1,218 @@
+/**
+ * @fileoverview ZCode data adapter for processing ZCode session usage from SQLite
+ *
+ * ZCode (the official GLM coding tool) records every model request as a row in
+ * a SQLite database at `~/.zcode/cli/db/db.sqlite` (table `model_usage`).
+ * Unlike Claude/Droid (JSONL), this adapter reads the database directly via
+ * `node:sqlite` and transforms each row into the {@link UsageData} shape so it
+ * merges transparently with Claude + Droid entries in the shared loaders.
+ *
+ * Each `model_usage` row maps to one `UsageData` entry: one row = one billable
+ * model request (a single turn may emit several rows). Retries are distinct
+ * rows keyed by `(logical_request_id, attempt_index)` and are counted as
+ * independent requests, matching how the provider bills them.
+ *
+ * @module zcode-adapter
+ */
+
+import type { LoadOptions, UsageData } from './data-loader.ts';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { DEFAULT_ZCODE_DB_SUBPATH, DEFAULT_ZCODE_HOME_PATH, USER_HOME_DIR, ZCODE_HOME_ENV } from './_consts.ts';
+import {
+	createISOTimestamp,
+	createMessageId,
+	createModelName,
+	createRequestId,
+	createSessionId,
+	createSource,
+	createVersion,
+} from './_types.ts';
+import { logger } from './logger.ts';
+
+/**
+ * Raw shape of a `model_usage` row joined with its `session`.
+ *
+ * `input_tokens` is the **total** prompt tokens billed at the input rate; the
+ * cached share (`cache_read_input_tokens`) is a subset of it and is priced
+ * separately at the cached rate. `output_tokens` already includes any
+ * reasoning charge. See the project CLAUDE.md for the full mapping table.
+ */
+type ModelUsageRow = {
+	started_at: number | bigint;
+	session_id: string;
+	model_id: string | null;
+	input_tokens: number | bigint;
+	cache_read_input_tokens: number | bigint;
+	cache_creation_input_tokens: number | bigint;
+	output_tokens: number | bigint;
+	logical_request_id: string | null;
+	attempt_index: number | bigint | null;
+	directory: string | null;
+};
+
+function toFiniteNumber(value: number | bigint | null | undefined): number {
+	if (value == null) {
+		return 0;
+	}
+	if (typeof value === 'bigint') {
+		return Number(value);
+	}
+	return Number.isFinite(value) ? value : 0;
+}
+
+const MODEL_USAGE_SQL = /* sql */ `
+	SELECT
+		mu.started_at,
+		mu.session_id,
+		mu.model_id,
+		mu.input_tokens,
+		mu.cache_read_input_tokens,
+		mu.cache_creation_input_tokens,
+		mu.output_tokens,
+		mu.logical_request_id,
+		mu.attempt_index,
+		s.directory
+	FROM model_usage AS mu
+	LEFT JOIN session AS s ON s.id = mu.session_id
+	WHERE mu.input_tokens > 0
+		OR mu.output_tokens > 0
+		OR mu.cache_read_input_tokens > 0
+		OR mu.cache_creation_input_tokens > 0
+	ORDER BY mu.started_at ASC
+`;
+
+/**
+ * Resolve the path to the ZCode SQLite database.
+ *
+ * Honors the `ZCODE_HOME` environment variable (resolved against the working
+ * directory when relative), otherwise falls back to `~/.zcode/cli/db/db.sqlite`.
+ */
+export function getZcodeDbPath(): string {
+	const envHome = process.env[ZCODE_HOME_ENV]?.trim();
+	if (envHome != null && envHome !== '') {
+		return path.resolve(envHome, DEFAULT_ZCODE_DB_SUBPATH);
+	}
+
+	if (process.env.VITEST != null) {
+		return '';
+	}
+
+	return path.join(USER_HOME_DIR, DEFAULT_ZCODE_HOME_PATH, DEFAULT_ZCODE_DB_SUBPATH);
+}
+
+/**
+ * Read all model-usage rows from the ZCode SQLite database and transform them
+ * into {@link UsageData} entries.
+ *
+ * The database is opened **read-only** so it never contends with the running
+ * ZCode process writing to the same file (SQLite handles concurrent WAL
+ * readers natively). Cost is intentionally NOT computed here — the shared
+ * loaders apply pricing downstream via `calculateCostForEntry`, exactly like
+ * the Droid adapter.
+ *
+ * @param dbPath - Absolute path to the ZCode SQLite database
+ * @returns Transformed usage entries (one per `model_usage` row)
+ */
+export async function processZcodeSessions(dbPath: string, _options: LoadOptions = {}): Promise<UsageData[]> {
+	if (dbPath === '') {
+		logger.debug('ZCode database path is empty, skipping');
+		return [];
+	}
+
+	if (!existsSync(dbPath)) {
+		logger.debug(`ZCode database not found at ${dbPath}`);
+		return [];
+	}
+
+	// Lazy-import node:sqlite so the module loads on runtimes that lack it
+	// (e.g. Bun, used by the schema generator) and on Node < 22.13. Only the
+	// actual ZCode code path triggers the import.
+	let DatabaseSync: typeof import('node:sqlite').DatabaseSync;
+	try {
+		({ DatabaseSync } = await import('node:sqlite'));
+	}
+	catch (error) {
+		logger.warn(`node:sqlite is not available on this runtime; ZCode usage disabled. ${String(error)}`);
+		return [];
+	}
+
+	let db: InstanceType<typeof DatabaseSync>;
+	try {
+		db = new DatabaseSync(dbPath, { readOnly: true });
+	}
+	catch (error) {
+		logger.warn(`Failed to open ZCode database at ${dbPath}: ${String(error)}`);
+		return [];
+	}
+
+	let rows: ModelUsageRow[];
+	try {
+		const statement = db.prepare(MODEL_USAGE_SQL);
+		rows = statement.all() as ModelUsageRow[];
+	}
+	catch (error) {
+		logger.warn(`Failed to query ZCode model_usage table: ${String(error)}`);
+		db[Symbol.dispose]();
+		return [];
+	}
+
+	db[Symbol.dispose]();
+
+	const results: UsageData[] = [];
+	for (const row of rows) {
+		const modelRaw = row.model_id?.trim();
+		if (modelRaw == null || modelRaw === '') {
+			// Without a model name we cannot price the row; skip it.
+			continue;
+		}
+
+		const inputTokens = toFiniteNumber(row.input_tokens);
+		const cacheReadTokens = toFiniteNumber(row.cache_read_input_tokens);
+		const cacheCreationTokens = toFiniteNumber(row.cache_creation_input_tokens);
+		const outputTokens = toFiniteNumber(row.output_tokens);
+		// ZCode tracks reasoning_tokens separately, but they are already included
+		// in output_tokens for billing, so we do not surface them in the usage
+		// object (the Claude schema has no field for it).
+		const timestamp = new Date(toFiniteNumber(row.started_at)).toISOString();
+
+		const sessionId = row.session_id ?? 'unknown-session';
+		// Stable message id so dedup keys are unique per request/attempt.
+		const logicalId = row.logical_request_id ?? sessionId;
+		const attemptIndex = toFiniteNumber(row.attempt_index);
+		const messageId = attemptIndex > 0 ? `${logicalId}#${attemptIndex}` : logicalId;
+
+		// ZCode's directory is the absolute working directory the session ran in.
+		// Group it under a `zcode` virtual root so it is distinguishable from
+		// Claude/Droid project paths, while keeping the real dir visible.
+		const cwd = row.directory != null && row.directory !== ''
+			? path.join('zcode', row.directory)
+			: path.join('zcode', 'unknown');
+
+		const entry: UsageData = {
+			timestamp: createISOTimestamp(timestamp),
+			sessionId: createSessionId(sessionId),
+			version: createVersion('1.0.0'),
+			message: {
+				usage: {
+					input_tokens: inputTokens,
+					output_tokens: outputTokens,
+					cache_creation_input_tokens: cacheCreationTokens,
+					cache_read_input_tokens: cacheReadTokens,
+				},
+				model: createModelName(modelRaw),
+				id: createMessageId(messageId),
+			},
+			// Cost will be calculated by better-ccusage based on model pricing.
+			requestId: createRequestId(messageId),
+			cwd,
+			source: createSource('zcode'),
+		};
+
+		results.push(entry);
+	}
+
+	logger.info(`Loaded ${results.length} ZCode usage entries from ${dbPath}`);
+	return results;
+}

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -70,6 +70,26 @@ export CLAUDE_CONFIG_DIR="/ci-data/claude-logs"
 better-ccusage daily --json > usage-report.json
 ```
 
+## ZCODE_HOME
+
+Specifies the ZCode home directory where better-ccusage should look for the usage SQLite database (`cli/db/db.sqlite`).
+
+```bash
+export ZCODE_HOME="/path/to/your/zcode/home"
+better-ccusage daily
+```
+
+When `ZCODE_HOME` is not set, better-ccusage automatically looks in:
+
+- **Linux/macOS**: `~/.zcode/cli/db/db.sqlite`
+- **Windows**: `C:\Users\<user>\.zcode\cli\db\db.sqlite`
+
+ZCode (the official GLM coding tool) records every model request in this database, so better-ccusage reads it directly — no manual export needed. The database is opened **read-only**, so it never interferes with a running ZCode process.
+
+::: tip Node.js requirement
+Reading the ZCode database requires Node.js `>=22.13.0` (when the built-in `node:sqlite` module stopped requiring the `--experimental-sqlite` flag). On older Node versions or alternative runtimes (e.g. Bun), ZCode data is silently skipped and Claude/Droid usage continues to work normally.
+:::
+
 ## LOG_LEVEL
 
 Controls the verbosity of log output. better-ccusage uses [consola](https://github.com/unjs/consola) for logging under the hood.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,11 +1,11 @@
 # Getting Started
 
-Welcome to better-ccusage! This guide will help you get up and running with analyzing your Claude Code/Droid Usage data.
+Welcome to better-ccusage! This guide will help you get up and running with analyzing your Claude Code/Droid/ZCode Usage data.
 
 ## Prerequisites
 
-- Claude Code installed and used (generates JSONL files)
-- Node.js 20+ or Bun runtime
+- Claude Code, Droid, or ZCode installed and used
+- Node.js 22.13+ or Bun runtime (ZCode usage requires Node.js 22.13+ for the built-in SQLite reader; Claude/Droid work on Node.js 20+)
 
 ## Quick Start
 
@@ -44,7 +44,7 @@ The tool automatically detects the provider from your usage data and calculates 
 
 ## Your First Report
 
-When you run better-ccusage for the first time, you'll see a table showing your Claude Code/Droid Usage by date:
+When you run better-ccusage for the first time, you'll see a table showing your Claude Code/Droid/ZCode Usage by date:
 
 ```
 ╭──────────────────────────────────────────╮

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,7 +2,7 @@
 
 ![better-ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**better-ccusage** (better-claude-code-usage) is a powerful CLI tool that analyzes your Claude Code/Droid Usage from local JSONL files to help you understand your token consumption patterns and estimated costs with multi-provider support.
+**better-ccusage** (better-claude-code-usage) is a powerful CLI tool that analyzes your Claude Code/Droid/ZCode Usage from local files to help you understand your token consumption patterns and estimated costs with multi-provider support.
 
 ## The Problem
 
@@ -106,7 +106,7 @@ better-ccusage extends the original ccusage functionality with support for multi
 
 ## Why better-ccusage?
 
-better-ccusage was created to address a limitation in the original ccusage project: while ccusage focuses exclusively on Claude Code usage with Anthropic models, better-ccusage extends support to external tools/providers that use Claude Code/Droid with different providers like Zai, Dashscope and many models like GLM-xx, kat-coder, kimi, MiniMax etc.
+better-ccusage was created to address a limitation in the original ccusage project: while ccusage focuses exclusively on Claude Code usage with Anthropic models, better-ccusage extends support to external tools/providers that use Claude Code/Droid/ZCode with different providers like Zai, Dashscope and many models like GLM-xx (including GLM-5.2), kat-coder, kimi, MiniMax etc.
 
 The original ccusage project doesn't account for:
 
@@ -145,4 +145,4 @@ The tool automatically detects and aggregates data from both locations for compa
 
 ## Getting Started
 
-Ready to analyze your Claude Code/Droid Usage? Check out our [Getting Started Guide](/guide/getting-started) to begin exploring your data!
+Ready to analyze your Claude Code/Droid/ZCode Usage? Check out our [Getting Started Guide](/guide/getting-started) to begin exploring your data!

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: better-ccusage
-  text: Claude Code/Droid Usage Analysis
-  tagline: A powerful CLI tool for analyzing Claude Code/Droid Usage from local JSONL files
+  text: Claude Code/Droid/ZCode Usage Analysis
+  tagline: A powerful CLI tool for analyzing Claude Code/Droid/ZCode Usage from local files
   image:
     src: /logo.svg
     alt: better-ccusage logo

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6717,9 +6717,9 @@
 	"zai/glm-5.2": {
 		"input_cost_per_token": 1.4e-6,
 		"provider": "zai",
-		"max_input_tokens": 204800,
+		"max_input_tokens": 1000000,
 		"max_output_tokens": 131072,
-		"max_tokens": 204800,
+		"max_tokens": 1000000,
 		"mode": "chat",
 		"output_cost_per_token": 4.4e-6,
 		"cache_creation_input_token_cost": 0,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6714,6 +6714,20 @@
 		"supports_tool_choice": true,
 		"supports_vision": false
 	},
+	"zai/glm-5.2": {
+		"input_cost_per_token": 1.4e-6,
+		"provider": "zai",
+		"max_input_tokens": 204800,
+		"max_output_tokens": 131072,
+		"max_tokens": 204800,
+		"mode": "chat",
+		"output_cost_per_token": 4.4e-6,
+		"cache_creation_input_token_cost": 0,
+		"cache_read_input_token_cost": 2.6e-7,
+		"supports_function_calling": true,
+		"supports_tool_choice": true,
+		"supports_vision": false
+	},
 	"zai/glm-5-turbo": {
 		"input_cost_per_token": 0.0000012,
 		"provider": "zai",

--- a/packages/internal/model_prices_and_context_window.json
+++ b/packages/internal/model_prices_and_context_window.json
@@ -6717,9 +6717,9 @@
 	"zai/glm-5.2": {
 		"input_cost_per_token": 1.4e-6,
 		"provider": "zai",
-		"max_input_tokens": 204800,
+		"max_input_tokens": 1000000,
 		"max_output_tokens": 131072,
-		"max_tokens": 204800,
+		"max_tokens": 1000000,
 		"mode": "chat",
 		"output_cost_per_token": 4.4e-6,
 		"cache_creation_input_token_cost": 0,

--- a/packages/internal/model_prices_and_context_window.json
+++ b/packages/internal/model_prices_and_context_window.json
@@ -6714,6 +6714,20 @@
 		"supports_tool_choice": true,
 		"supports_vision": false
 	},
+	"zai/glm-5.2": {
+		"input_cost_per_token": 1.4e-6,
+		"provider": "zai",
+		"max_input_tokens": 204800,
+		"max_output_tokens": 131072,
+		"max_tokens": 204800,
+		"mode": "chat",
+		"output_cost_per_token": 4.4e-6,
+		"cache_creation_input_token_cost": 0,
+		"cache_read_input_token_cost": 2.6e-7,
+		"supports_function_calling": true,
+		"supports_tool_choice": true,
+		"supports_vision": false
+	},
 	"zai/glm-5-turbo": {
 		"input_cost_per_token": 0.0000012,
 		"provider": "zai",

--- a/packages/internal/src/model_prices_and_context_window.json
+++ b/packages/internal/src/model_prices_and_context_window.json
@@ -6717,9 +6717,9 @@
 	"zai/glm-5.2": {
 		"input_cost_per_token": 1.4e-6,
 		"provider": "zai",
-		"max_input_tokens": 204800,
+		"max_input_tokens": 1000000,
 		"max_output_tokens": 131072,
-		"max_tokens": 204800,
+		"max_tokens": 1000000,
 		"mode": "chat",
 		"output_cost_per_token": 4.4e-6,
 		"cache_creation_input_token_cost": 0,

--- a/packages/internal/src/model_prices_and_context_window.json
+++ b/packages/internal/src/model_prices_and_context_window.json
@@ -6714,6 +6714,20 @@
 		"supports_tool_choice": true,
 		"supports_vision": false
 	},
+	"zai/glm-5.2": {
+		"input_cost_per_token": 1.4e-6,
+		"provider": "zai",
+		"max_input_tokens": 204800,
+		"max_output_tokens": 131072,
+		"max_tokens": 204800,
+		"mode": "chat",
+		"output_cost_per_token": 4.4e-6,
+		"cache_creation_input_token_cost": 0,
+		"cache_read_input_token_cost": 2.6e-7,
+		"supports_function_calling": true,
+		"supports_tool_choice": true,
+		"supports_vision": false
+	},
 	"zai/glm-5-turbo": {
 		"input_cost_per_token": 0.0000012,
 		"provider": "zai",

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -155,7 +155,15 @@ export class ResponsiveTable {
 
 		const contentWidths = head.map((_, colIndex) => {
 			const maxLength = Math.max(
-				...allRows.map(row => stringWidth(String(row[colIndex] ?? ''))),
+				...allRows.map((row) => {
+					const cell = String(row[colIndex] ?? '');
+					// Multi-line cells (e.g. stacked sources/models) must be measured
+					// per line: stringWidth counts '\n' as zero-width and would
+					// otherwise report the concatenated width of all lines, which is
+					// wider than any single rendered line and starves other columns.
+					const lines = cell.split('\n');
+					return Math.max(...lines.map(line => stringWidth(line)));
+				}),
 			);
 			return maxLength;
 		});
@@ -165,7 +173,10 @@ export class ResponsiveTable {
 		const tableOverhead = 3 * numColumns + 1; // borders and separators
 		const availableWidth = terminalWidth - tableOverhead;
 
-		// Always use content-based widths with generous padding for numeric columns
+		// Always use content-based widths with generous padding for numeric columns.
+		// cli-table3 reserves 1 char of internal padding on each side of a cell,
+		// so colWidth must be content + 2 to render the full value (otherwise
+		// e.g. '2026-06' at width 8 becomes '2026-…').
 		const columnWidths = contentWidths.map((width, index) => {
 			const align = colAligns[index];
 			if (align === 'right') {
@@ -175,7 +186,11 @@ export class ResponsiveTable {
 				// Models column - allow full content width
 				return Math.max(width + 2, 12);
 			}
-			return Math.max(width + 1, 8);
+			else if (index === 0) {
+				// First column (Date/Month) - needs room for the value + padding
+				return Math.max(width + 2, 8);
+			}
+			return Math.max(width + 2, 8);
 		});
 
 		// Check if this fits in the terminal

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -365,6 +365,24 @@ export function formatModelsDisplayMultiline(models: string[]): string {
 }
 
 /**
+ * Formats a (possibly combined) source label for multi-line display.
+ *
+ * Combined sources are joined with '/' in a canonical order (e.g.
+ * 'claude/droid/zcode'). On narrow terminals this gets truncated, so we split
+ * it across lines — one source per line — mirroring the way the Models column
+ * stacks entries. A single source is returned unchanged.
+ *
+ * @param source - The source label, e.g. 'claude', 'claude/zcode'
+ * @returns The label with each source on its own line, or the original string
+ */
+export function formatSourceMultiline(source: string): string {
+	if (!source.includes('/')) {
+		return source;
+	}
+	return source.split('/').join('\n');
+}
+
+/**
  * Pushes model breakdown rows to a table
  * @param table - The table to push rows to
  * @param table.push - Method to add rows to the table
@@ -526,7 +544,7 @@ export function formatUsageDataRow(
 
 	const row: (string | number)[] = [
 		firstColumnValue,
-		data.source ?? 'claude', // Use source if provided, default to 'claude' only if null/undefined
+		formatSourceMultiline(data.source ?? 'claude'), // Split combined sources across lines for readability
 		data.modelsUsed != null ? formatModelsDisplay(data.modelsUsed) : '',
 		formatNumber(data.inputTokens),
 		formatNumber(data.outputTokens),

--- a/packages/terminal/src/table.ts
+++ b/packages/terminal/src/table.ts
@@ -1036,4 +1036,21 @@ if (import.meta.vitest != null) {
 			expect(formatModelsDisplayMultiline(models)).toBe('- opus-4-1\n- sonnet-4\n- sonnet-4-5');
 		});
 	});
+
+	describe('formatSourceMultiline', () => {
+		it('returns a single source unchanged', () => {
+			expect(formatSourceMultiline('claude')).toBe('claude');
+			expect(formatSourceMultiline('droid')).toBe('droid');
+			expect(formatSourceMultiline('zcode')).toBe('zcode');
+		});
+
+		it('splits a two-source combination across lines', () => {
+			expect(formatSourceMultiline('claude/droid')).toBe('claude\ndroid');
+			expect(formatSourceMultiline('claude/zcode')).toBe('claude\nzcode');
+		});
+
+		it('splits a three-source combination across lines', () => {
+			expect(formatSourceMultiline('claude/droid/zcode')).toBe('claude\ndroid\nzcode');
+		});
+	});
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6396,7 +6396,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.25':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@vue/shared': 3.5.25
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -6576,7 +6576,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       pathe: 2.0.3
 
   bail@2.0.2: {}
@@ -8528,7 +8528,7 @@ snapshots:
   rolldown-plugin-dts@0.18.4(@typescript/native-preview@7.0.0-dev.20251201.1)(rolldown@1.0.0-beta.52(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.1))(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 4.0.0


### PR DESCRIPTION
## Summary

Adds **ZCode** (the official GLM coding tool) as a first-class usage source in the main `better-ccusage` app, alongside Claude and Droid. ZCode records every model request in a SQLite database at `~/.zcode/cli/db/db.sqlite`; this PR reads it via `node:sqlite` and merges the entries into the existing daily/session/blocks loaders, following the same adapter pattern as Droid.

Also fixes two preexisting terminal rendering bugs that surfaced while validating the integration.

## What ZCode exposes

The `model_usage` table contains everything needed for usage/cost tracking — one row per model request (a turn may emit several):

| Column | Meaning |
|---|---|
| `model_id` | Model reported by provider (e.g. `GLM-5.2`) |
| `input_tokens` | Total prompt tokens (includes the cached share) |
| `cache_read_input_tokens` | Prompt tokens satisfied from cache |
| `output_tokens` | Completion tokens (reasoning included) |
| `started_at` | Unix epoch **milliseconds** |
| `session_id` / `turn_id` / `agent` / `query_source` | Request context |

Cost is computed by the shared `PricingFetcher` (never stored by ZCode), exactly like Codex/OpenCode.

## Changes

### ZCode integration (`apps/better-ccusage/`)
- **`src/zcode-adapter.ts`** *(new)*: `processZcodeSessions()` reads the SQLite DB read-only via `node:sqlite` (lazy-imported so the module also loads under Bun and Node <22.13) and returns `UsageData[]`.
- **`src/_types.ts`**: extended `sourceSchema` picklist to include `zcode` and its combinations (`claude/zcode`, `droid/zcode`, `claude/droid/zcode`).
- **`src/_consts.ts`**: `ZCODE_HOME` env var + default path constants.
- **`src/data-loader.ts`**: wired zcode into `loadDailyUsageData`, `loadSessionData`, `loadSessionBlockData`; generalized the per-group `combinedSource` logic into `combineSources()`.
- **`package.json`**: `engines.node` bumped to `>=22.13.0` (node:sqlite requirement).

### Pricing
- Added `zai/glm-5.2` to `model_prices_and_context_window.json` (mirrors `glm-5.1`: $1.4 / $4.4 / $0.26 per M tokens, cache-write free).

### Terminal rendering fixes (`packages/terminal/`)
- **Multi-line source**: combined sources like `claude/zcode` now stack on separate lines in the Source column (mirroring how Models already stack), instead of truncating to `claude/zco...`.
- **Column width bug**: cli-table3 reserves 1 char of internal padding per cell, so a `colWidth` equal to the content length truncated the value (`2026-06` -> `2026-...`). Fixed by measuring multi-line cells per-line and adding the padding the first column needs.

## Validation

- **291 tests** (better-ccusage) + **34 tests** (terminal) pass
- typecheck, lint, build all green
- Validated against a real ZCode DB (17.5k+ `model_usage` rows): source correctly labeled, cost matches manual calculation

## Test plan
- [ ] `better-ccusage daily` shows a `Source` column with `claude`, `droid`, and/or `zcode` when those tools have data
- [ ] `better-ccusage monthly` shows combined sources stacked multi-line (e.g. `claude` / `zcode` in one row)
- [ ] Month column renders fully (`2026-06`, not `2026-...`)
- [ ] `--json` output includes `source` per entry
- [ ] No regression for Claude-only or Droid-only users (existing tests cover this)

## Breaking change note
`engines.node` moves from `>=20.19.4` to `>=22.13.0` for `better-ccusage`. This is required by `node:sqlite` (stable without flag since 22.13.0). Node 22 LTS shipped Oct 2024.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ZCode usage data alongside existing sources, including local database detection and report aggregation.
  * Added support for the `zai/glm-5.2` model with pricing and token limit details.
  * Source labels in tables now display combined sources on separate lines for easier reading.

* **Bug Fixes**
  * Improved table width calculation for multi-line cells, making column alignment more consistent.

* **Chores**
  * Updated the minimum required Node.js version for the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->