### PR TITLE
fix(pricing): check OFFLINE before cache; clarify merged-unique counts

### DIFF
--- a/packages/internal/src/remote-pricing.ts
+++ b/packages/internal/src/remote-pricing.ts
@@ -237,7 +237,17 @@ export async function loadMergedPricing(): Promise<Record<string, ModelPricing>>
 	const staticData = loadLocalPricingDataset();
 	const staticCount = Object.keys(staticData).length;
 
-	// Step 2: Check cache (24h TTL). When fresh, skip the network entirely.
+	// Step 2: OFFLINE short-circuits everything. Must be checked BEFORE the
+	// cache so OFFLINE=true truly means "bundled dataset only" even when a
+	// fresh 24h cache exists on disk.
+	if (process.env.OFFLINE === 'true') {
+		console.warn(
+			`[better-ccusage] Pricing: OFFLINE mode, using bundled dataset only (${staticCount} models).`,
+		);
+		return staticData;
+	}
+
+	// Step 3: Check cache (24h TTL). When fresh, skip the network entirely.
 	const cache = readCacheFile();
 	if (cache != null) {
 		const cacheCount = Object.keys(cache.dataset).length;
@@ -246,18 +256,10 @@ export async function loadMergedPricing(): Promise<Record<string, ModelPricing>>
 		const ageMin = Math.max(0, Math.round((Date.now() - cache.timestamp) / 60000));
 		console.warn(
 			`[better-ccusage] Pricing: using cached dataset (${ageMin}min old).`
-			+ ` ${cacheCount} cached + ${staticCount} bundled = ${mergedCount} models`
+			+ ` ${cacheCount} cached, ${staticCount} bundled, ${mergedCount} merged unique models`
 			+ ` (bundled entries take priority).`,
 		);
 		return merged;
-	}
-
-	// Step 3: Skip remote fetch if OFFLINE
-	if (process.env.OFFLINE === 'true') {
-		console.warn(
-			`[better-ccusage] Pricing: OFFLINE mode, using bundled dataset only (${staticCount} models).`,
-		);
-		return staticData;
 	}
 
 	// Step 4: Fetch remote (this runs at most once per 24h thanks to the cache)
@@ -269,7 +271,7 @@ export async function loadMergedPricing(): Promise<Record<string, ModelPricing>>
 		const mergedCount = Object.keys(merged).length;
 		console.warn(
 			`[better-ccusage] Pricing: fetched ${remoteCount} models from LiteLLM.`
-			+ ` Merged with ${staticCount} bundled = ${mergedCount} models`
+			+ ` ${remoteCount} remote, ${staticCount} bundled, ${mergedCount} merged unique models`
 			+ ` (bundled entries take priority).`,
 		);
 

--- a/packages/internal/src/remote-pricing.ts
+++ b/packages/internal/src/remote-pricing.ts
@@ -271,7 +271,7 @@ export async function loadMergedPricing(): Promise<Record<string, ModelPricing>>
 		const mergedCount = Object.keys(merged).length;
 		console.warn(
 			`[better-ccusage] Pricing: fetched ${remoteCount} models from LiteLLM.`
-			+ ` ${remoteCount} remote, ${staticCount} bundled, ${mergedCount} merged unique models`
+			+ ` ${staticCount} bundled, ${mergedCount} merged unique models`
 			+ ` (bundled entries take priority).`,
 		);
 


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review comments posted on #42 **after** it was merged (the bot reviewed the merged commit). This is the follow-up fix before the 1.6.0 release.

## Fixes

### 1. 🔴 OFFLINE=true was ignored when a fresh cache existed (Major)

The cache branch returned before the OFFLINE check, so  never actually meant "bundled dataset only" on any machine that had already run the tool once (i.e. had a fresh 24h cache). The log even said "using cached dataset" in OFFLINE mode — contradicting the documented behavior.

**Fix**: check  first, short-circuit before .



**Verified**:  + fresh cache now logs  (previously fell into the cache branch).

### 2. 🟡 Log wording implied counts sum to total (Minor)

`100 cached + 20 bundled = 110 models` is misleading because the datasets overlap (bundled entries override cached of the same name, so the operands don't add up). Reworded to `100 cached, 20 bundled, 110 merged unique models`.

## Tests
- 30 internal tests pass, typecheck clean
- Real-data verification of the OFFLINE+cache scenario (the bug case)

## Note
This is a pure fix-up for the already-merged #42. Once merged, main will be ready for the 1.6.0 release.