### PR TITLE
chore: gitignore .npmrc (auth) and .zcode/ (local agent artifacts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # npm credentials (never commit auth tokens)
 .npmrc
-**/.npmrc
 
 # caches
 .eslintcache

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .env.production.local
 .env.local
 
+# npm credentials (never commit auth tokens)
+.npmrc
+**/.npmrc
+
 # caches
 .eslintcache
 .cache
@@ -45,3 +49,6 @@ settings.local.json
 
 # temporary LiteLLM pricing snapshot (used for ad-hoc pricing research)
 .litellm-latest.json
+
+# local ZCode agent artifacts (plans, scratch, etc.)
+.zcode/


### PR DESCRIPTION
## Summary

Small hygiene change to  after the 1.6.0 release:

- ** / **: prevent accidentally committing npm auth tokens. We use just-in-time  files for manual MCP publishes (when the CI publish fails), and these must never ship. This was caught when publishing MCP 1.6.0 manually — the file showed up as untracked until we added the ignore rule.

- ****: local ZCode agent artifacts (plans, scratch space) that were leaking as untracked files in recent sessions.

## Why not on main directly?
The 1.6.0 publish already happened (all 4 packages on npm), so this is purely preventive for future work. Branching per the post-#42 process: PR → review → manual merge.