### PR TITLE
fix(release): split publish into core + dependent jobs for clean exports

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,28 @@ on:
     tags:
       - "*"
 
+# Serialize releases: if two tags are pushed close together, the second run
+# waits for the first instead of racing on the same npm versions.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  npm:
+  # Job 1: publish the core `better-ccusage` package first.
+  #
+  # Why split: the core prepack runs `clean-pkg-json`, which strips the dev
+  # `exports` (./src/data-loader, ./src/logger, ...) from
+  # apps/better-ccusage/package.json on disk. If dependent apps (mcp) were
+  # published in the same checkout afterwards, their build would fail with
+  # RESOLVE_ERROR on `better-ccusage/*` imports, because the source package.json
+  # no longer exposes those subpaths. Splitting into two jobs gives the
+  # dependent-apps job a fresh checkout.
+  #
+  # Why idempotent: on retry (e.g. publish-apps failed mid-way), publish-core
+  # would otherwise fail with `npm 403 cannot publish over`. We pre-check
+  # `npm view <pkg>@<version>` and skip publishing if the version already
+  # exists, so a retry only publishes what is missing.
+  publish-core:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -23,14 +43,82 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version: lts/*
       - run: pnpm install --no-frozen-lockfile
-      - run: pnpm --filter='./apps/**' publish --provenance --no-git-checks --access public
+      - name: Check if better-ccusage@<version> already on npm
+        id: check-core
+        run: |
+          VERSION=$(node -p "require('./apps/better-ccusage/package.json').version")
+          if npm view "better-ccusage@${VERSION}" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "better-ccusage@${VERSION} already published, skipping publish-core."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish better-ccusage (core)
+        if: steps.check-core.outputs.exists != 'true'
+        run: pnpm --filter='better-ccusage' publish --provenance --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Job 2: publish the dependent apps in a fresh checkout. The core package.json
+  # here is the unmodified source, so clean-pkg-json hasn't stripped its dev
+  # exports. The apps resolve `better-ccusage/*` via the pnpm workspace symlink
+  # (workspace:* protocol), NOT from the npm registry, so publish-core running
+  # first is a release-ordering concern for end users, not a build-time
+  # requirement.
+  #
+  # Like publish-core, this job is idempotent: it checks each app's version on
+  # npm and only publishes the ones that are missing, so a retry after a
+  # partial failure does not crash on already-published versions.
+  publish-apps:
+    needs: publish-core
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          registry-url: "https://registry.npmjs.org"
+          node-version: lts/*
+      - run: pnpm install --no-frozen-lockfile
+      - name: Publish each missing dependent app
+        # Publish the three dependent apps. We list them explicitly rather than
+        # using `@better-ccusage/*` because that glob also matches
+        # @better-ccusage/{internal, terminal, docs} (all private). Caveat:
+        # `pnpm --filter` does NOT fail when a name is unknown, so this list
+        # must be kept in sync manually with the actual app package names.
+        # For each app we first check `npm view` to skip already-published
+        # versions, making this job safe to retry.
+        # NB: GitHub Actions runs `run: |` with `set -e` by default, so a single
+        # failed publish aborts the whole step (fail-fast). The remaining apps
+        # will be retried on the next run thanks to the per-app `npm view` skip.
+        run: |
+          for app in codex mcp opencode; do
+            pkg="@better-ccusage/${app}"
+            dir="apps/${app}"
+            version=$(node -p "require('./${dir}/package.json').version")
+            if npm view "${pkg}@${version}" version >/dev/null 2>&1; then
+              echo "${pkg}@${version} already published, skipping."
+              continue
+            fi
+            echo "Publishing ${pkg}@${version}..."
+            pnpm --filter="${pkg}" publish --provenance --no-git-checks --access public
+          done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release:
     needs:
-      - npm
+      - publish-core
+      - publish-apps
     runs-on: ubuntu-slim
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,11 @@ on:
     tags:
       - "*"
 
-# Serialize releases: if two tags are pushed close together, the second run
-# waits for the first instead of racing on the same npm versions.
+# Serialize ALL release runs globally. A static group name (rather than one
+# per tag via github.ref) ensures that two different tags pushed close
+# together queue instead of racing on npm publish / GitHub release creation.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Fixes the release workflow that caused the 1.6.0 first-run publish to fail on `@better-ccusage/mcp` (published manually as a workaround).

## Root cause
The previous single-job publish ran `pnpm --filter='./apps/**' publish` in one checkout. `better-ccusage` was published first; its prepack runs `clean-pkg-json`, which strips the dev `exports` (`./src/data-loader`, `./src/logger`, ...) from `apps/better-ccusage/package.json` on disk. When `mcp` was published last in the sequence, its build failed with `RESOLVE_ERROR on 'better-ccusage/data-loader'` because the core package.json no longer exposed that subpath.

## Fix
Split into two jobs, each with a **fresh checkout**:
- `publish-core` — publishes only `better-ccusage`
- `publish-apps` (`needs: publish-core`) — publishes codex, mcp, opencode by exact package name

Because each job checks out the repo fresh, the core `package.json` in `publish-apps` is the unmodified source, so the dependent apps resolve `better-ccusage/*` via the pnpm workspace symlink as usual. (`needs:` is a release-ordering concern for end users, not a build-time requirement.)

## Idempotence / retry safety
Both publish jobs pre-check `npm view <pkg>@<version>` and **skip if already published**. Without this, retrying a partially-failed run would crash on `npm 403 cannot publish over` and the dependent-apps job would never run, leaving apps unpublished.

## Other hardening
- Workflow-level `concurrency: release-${{ github.ref }}` so two tag pushes can't race.
- `timeout-minutes: 5` on the release (changelog) job.
- Comments document the per-app fail-fast behaviour under `set -e`, and the caveat that `pnpm --filter` is silent on unknown names.

## Validation
- 2 read-only code-review passes (subagent): 1st found a major idempotence regression from the initial draft, fixed in this version; 2nd confirmed all issues resolved.
- YAML validated.
- Tested pnpm filters locally (`better-ccusage` matches core only; the 3 `@better-ccusage/*` match apps only).

## Notes
- The legacy broken `publish.yml` workflow (YAML syntax error, never succeeded) is not touched here — could be removed in a follow-up.
- An hourly/daily `update-pricing` automation (like upstream ccusage) was considered but deferred: our runtime fetch + cache is already a safety net, and the ROI of full automation is low given we run `sync-pricing` before each release. Separate concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by preventing duplicate package versions from being published.
  * Ensured core and app packages are released in the correct order.
  * Serialized concurrent release runs to avoid conflicts.
  * Allowed releases to continue publishing any packages that are not already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->