### PR TITLE
fix(blocks): compute cost for droid and zcode via calculateCostForEntry

### DIFF
--- a/apps/better-ccusage/src/data-loader.ts
+++ b/apps/better-ccusage/src/data-loader.ts
@@ -1860,7 +1860,7 @@ export async function loadSessionBlockData(
 			logger.debug(`Attempting to load droid sessions for blocks from ${droidPath}`);
 			const rawDroidEntries = await processDroidSessions(droidPath, options);
 			// Convert droid entries to LoadedUsageEntry format with Date timestamps
-			droidEntries = rawDroidEntries.map((entry): LoadedUsageEntry => ({
+			droidEntries = await Promise.all(rawDroidEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
 				timestamp: new Date(entry.timestamp),
 				usage: {
 					inputTokens: entry.message.usage.input_tokens,
@@ -1868,12 +1868,18 @@ export async function loadSessionBlockData(
 					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
 					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
 				},
-				costUSD: entry.costUSD ?? 0,
+				// Droid entries do not carry a pre-computed costUSD (the adapter
+				// delegates pricing to the shared engine), so we must compute it
+				// here with the same fetcher/mode as the Claude path. Without
+				// this, every droid session block would report $0.
+				costUSD: fetcher == null
+					? entry.costUSD ?? 0
+					: await calculateCostForEntry(entry, mode, fetcher),
 				model: entry.message.model ?? 'unknown',
 				version: entry.version ?? undefined,
 				usageLimitResetTime: undefined,
 				source: entry.source ?? 'droid',
-			}));
+			})));
 			logger.info(`Loaded ${droidEntries.length} droid entries for blocks from ${droidPath}`);
 		}
 		catch (error) {
@@ -1891,8 +1897,11 @@ export async function loadSessionBlockData(
 	else {
 		try {
 			const rawZcodeEntries = await processZcodeSessions(zcodeDbPath, options);
-			// Convert zcode entries to LoadedUsageEntry format with Date timestamps
-			zcodeEntries = rawZcodeEntries.map((entry): LoadedUsageEntry => ({
+			// ZCode entries do not carry a pre-computed costUSD (the adapter
+			// delegates pricing to the shared engine), so we must compute it
+			// here with the same fetcher/mode as the Claude path. Without
+			// this, every zcode session block would report $0.
+			zcodeEntries = await Promise.all(rawZcodeEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
 				timestamp: new Date(entry.timestamp),
 				usage: {
 					inputTokens: entry.message.usage.input_tokens,
@@ -1900,12 +1909,14 @@ export async function loadSessionBlockData(
 					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
 					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
 				},
-				costUSD: entry.costUSD ?? 0,
+				costUSD: fetcher == null
+					? entry.costUSD ?? 0
+					: await calculateCostForEntry(entry, mode, fetcher),
 				model: entry.message.model ?? 'unknown',
 				version: entry.version ?? undefined,
 				usageLimitResetTime: undefined,
 				source: entry.source ?? 'zcode',
-			}));
+			})));
 		}
 		catch (error) {
 			logger.warn(`Failed to load zcode sessions for blocks: ${String(error)}`);

--- a/apps/better-ccusage/src/opencode-adapter.ts
+++ b/apps/better-ccusage/src/opencode-adapter.ts
@@ -314,6 +314,7 @@ if (import.meta.vitest != null) {
 	// Hoist the sqlite import once for all tests (CLAUDE.md discourages
 	// repeated `await import()` in test bodies; the runtime-detection
 	// justification from the production code does not apply under vitest).
+	// eslint-disable-next-line antfu/no-top-level-await -- test-only hoisted import inside the vitest guard
 	const { DatabaseSync } = await import('node:sqlite');
 
 	describe('processOpenCodeSessions', () => {


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug in `loadSessionBlockData`: the droid and zcode source mappings used `costUSD: entry.costUSD ?? 0`, but since `processDroidSessions` and `processZcodeSessions` never set `costUSD` (they delegate pricing to the shared engine), every droid/zcode session block reported **$0** — tokens counted, cost invisible.

This is the same bug that was fixed for codex in #41 and avoided for opencode in #46, but never backported to droid/zcode.

## Fix
Convert the synchronous `.map` to `await Promise.all(.map(async ...))` and use `calculateCostForEntry(entry, mode, fetcher)` — exactly like the claude/codex/opencode paths.

## Real-data verification
| | Before | After |
|---|---|---|
| droid/zcode blocks at $0 | 85 | **0** |
| droid/zcode blocks with cost > 0 | 27 | **112** |
| Total droid/zcode cost visible in blocks | (invisible) | **$6,667.11** |

## Also fixes
A pre-existing lint regression from #46: the hoisted `await import('node:sqlite')` in opencode-adapter tests violated `antfu/no-top-level-await`. Added `eslint-disable-next-line` with a test-only justification (production lazy import unchanged).

## Tests
- 304 tests pass, typecheck clean, lint clean.
- Code review subagent pre-push found a MAJOR indentation regression in the zcode block (fixed before commit).

## Follow-up (out of scope)
- Add an integration test in `describe('loadSessionBlockData')` covering droid/zcode cost (currently requires mocking getDroidPath/getZcodeDbPath which return '' under VITEST — non-trivial). The fix is proven on real data and the pattern is now identical across all 5 sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usage blocks for droid and zcode entries so costs are calculated correctly instead of appearing as $0 when pricing information is available.

* **Tests**
  * Updated test-only setup to prevent linting issues without affecting runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->