### PR TITLE
refactor(types): generate sourceSchema picklist from SOURCE_ORDER

### DIFF
--- a/apps/better-ccusage/src/_consts.ts
+++ b/apps/better-ccusage/src/_consts.ts
@@ -45,6 +45,46 @@ export const USER_HOME_DIR = homedir();
 const XDG_CONFIG_DIR = xdgConfig ?? path.join(USER_HOME_DIR, '.config');
 
 /**
+ * Canonical order of usage data sources.
+ *
+ * Single source of truth for the source enumeration. Drives both
+ * `combineSources()` (canonical ordering of grouped labels) and the valibot
+ * `sourceSchema` picklist (via `SOURCE_SUBSETS`). Add a new source here and
+ * both the combiner and the schema pick up the extra atom automatically.
+ */
+export const SOURCE_ORDER = ['claude', 'droid', 'zcode', 'codex', 'opencode'] as const;
+
+/**
+ * All non-empty subsets of {@link SOURCE_ORDER}, joined by '/' in canonical
+ * order. Generated at module load so the list stays in sync with
+ * `SOURCE_ORDER` (2^n - 1 combinations for n sources).
+ *
+ * Enumeration order: for atoms [a, b, c, ...] we emit `a` and `a/` prepended
+ * to each subset of the tail first, then the subsets of the tail. This keeps
+ * every source's atom contiguous and matches the order the previous hand-
+ * written picklist used (all subsets containing the first atom, then those
+ * without), so existing snapshots/debug output are unchanged.
+ *
+ * The runtime array always contains the exact subset strings, so valibot's
+ * `picklist` still validates values precisely. Note the branded `Source` type
+ * widens to `string & Brand<'Source'>` (no literal union) because the
+ * generated array is not a literal tuple — no consumer relies on literal
+ * narrowing, and the validation boundary stays exact.
+ */
+function generateSourceSubsets(atoms: readonly string[]): readonly [string, ...string[]] {
+	if (atoms.length === 0) {
+		return [] as unknown as readonly [string, ...string[]];
+	}
+	const [first, ...rest] = atoms;
+	const tailSubsets = generateSourceSubsets(rest);
+	const withFirst = [first, ...tailSubsets.map(s => `${first}/${s}`)];
+	const result = [...withFirst, ...tailSubsets];
+	return result as unknown as readonly [string, ...string[]];
+}
+
+export const SOURCE_SUBSETS = generateSourceSubsets(SOURCE_ORDER);
+
+/**
  * Default Claude data directory path (~/.claude)
  * Used as base path for loading usage data from JSONL files
  */

--- a/apps/better-ccusage/src/_consts.ts
+++ b/apps/better-ccusage/src/_consts.ts
@@ -71,18 +71,20 @@ export const SOURCE_ORDER = ['claude', 'droid', 'zcode', 'codex', 'opencode'] as
  * generated array is not a literal tuple — no consumer relies on literal
  * narrowing, and the validation boundary stays exact.
  */
-function generateSourceSubsets(atoms: readonly string[]): readonly [string, ...string[]] {
-	if (atoms.length === 0) {
-		return [] as unknown as readonly [string, ...string[]];
-	}
+function generateSourceSubsets(atoms: readonly string[]): readonly string[] {
 	const [first, ...rest] = atoms;
+	if (first === undefined) {
+		return [];
+	}
 	const tailSubsets = generateSourceSubsets(rest);
 	const withFirst = [first, ...tailSubsets.map(s => `${first}/${s}`)];
-	const result = [...withFirst, ...tailSubsets];
-	return result as unknown as readonly [string, ...string[]];
+	return [...withFirst, ...tailSubsets];
 }
 
-export const SOURCE_SUBSETS = generateSourceSubsets(SOURCE_ORDER);
+// SOURCE_ORDER is guaranteed non-empty, so the result is a non-empty tuple.
+// Cast at the export boundary so valibot's `picklist` (which rejects a widened
+// `string[]`) accepts it; the helper itself stays honestly typed.
+export const SOURCE_SUBSETS = generateSourceSubsets(SOURCE_ORDER) as unknown as readonly [string, ...string[]];
 
 /**
  * Default Claude data directory path (~/.claude)

--- a/apps/better-ccusage/src/_types.ts
+++ b/apps/better-ccusage/src/_types.ts
@@ -1,6 +1,8 @@
 import type { TupleToUnion } from 'type-fest';
 import * as v from 'valibot';
 
+import { SOURCE_SUBSETS } from './_consts.ts';
+
 /**
  * Branded Valibot schemas for type safety using brand markers.
  */
@@ -78,45 +80,12 @@ export const projectPathSchema = v.pipe(
 	v.brand('ProjectPath'),
 );
 
-// All non-empty subsets of {claude, droid, zcode, codex, opencode} joined by
-// '/' in canonical order. Enumerated explicitly (rather than computed) because
-// valibot's picklist needs a literal array. Keep in sync with SOURCE_ORDER in
-// data-loader.ts when adding/removing a source.
+// All non-empty subsets of the known sources, joined by '/' in canonical
+// order. Generated from SOURCE_ORDER (see _consts.ts) so adding/removing a
+// source updates both the combiner and this schema automatically.
 export const sourceSchema = v.pipe(
 	v.string(),
-	v.picklist([
-		'claude',
-		'claude/droid',
-		'claude/droid/zcode',
-		'claude/droid/zcode/codex',
-		'claude/droid/zcode/codex/opencode',
-		'claude/droid/zcode/opencode',
-		'claude/droid/codex',
-		'claude/droid/codex/opencode',
-		'claude/droid/opencode',
-		'claude/zcode',
-		'claude/zcode/codex',
-		'claude/zcode/codex/opencode',
-		'claude/zcode/opencode',
-		'claude/codex',
-		'claude/codex/opencode',
-		'claude/opencode',
-		'droid',
-		'droid/zcode',
-		'droid/zcode/codex',
-		'droid/zcode/codex/opencode',
-		'droid/zcode/opencode',
-		'droid/codex',
-		'droid/codex/opencode',
-		'droid/opencode',
-		'zcode',
-		'zcode/codex',
-		'zcode/codex/opencode',
-		'zcode/opencode',
-		'codex',
-		'codex/opencode',
-		'opencode',
-	]),
+	v.picklist(SOURCE_SUBSETS),
 	v.brand('Source'),
 );
 

--- a/apps/better-ccusage/src/data-loader.ts
+++ b/apps/better-ccusage/src/data-loader.ts
@@ -28,7 +28,7 @@ import { createFixture } from 'fs-fixture';
 import { isDirectorySync } from 'path-type';
 import { glob } from 'tinyglobby';
 import * as v from 'valibot';
-import { CLAUDE_CONFIG_DIR_ENV, CLAUDE_PROJECTS_DIR_NAME, DEFAULT_CLAUDE_CODE_PATH, DEFAULT_CLAUDE_CONFIG_PATH, DEFAULT_LOCALE, USAGE_DATA_GLOB_PATTERN, USER_HOME_DIR } from './_consts.ts';
+import { CLAUDE_CONFIG_DIR_ENV, CLAUDE_PROJECTS_DIR_NAME, DEFAULT_CLAUDE_CODE_PATH, DEFAULT_CLAUDE_CONFIG_PATH, DEFAULT_LOCALE, SOURCE_ORDER, USAGE_DATA_GLOB_PATTERN, USER_HOME_DIR } from './_consts.ts';
 import {
 	filterByDateRange,
 	formatDate,
@@ -563,14 +563,12 @@ export function createUniqueHash(data: UsageData): string | null {
 /**
  * Build a combined source label from the set of tool sources present in a group.
  *
- * Sources are joined with '/' in a stable canonical order (claude, droid, zcode)
- * so grouped rows surface every contributing tool. Inputs may already be
- * combined labels (e.g. `claude/droid` from a daily rollup); those are split
- * first so the canonical ordering is preserved. An empty set defaults to
- * 'claude' for backward compatibility with Claude-only data.
+ * Sources are joined with '/' in a stable canonical order (see SOURCE_ORDER in
+ * _consts.ts) so grouped rows surface every contributing tool. Inputs may
+ * already be combined labels (e.g. `claude/droid` from a daily rollup); those
+ * are split first so the canonical ordering is preserved. An empty set defaults
+ * to 'claude' for backward compatibility with Claude-only data.
  */
-const SOURCE_ORDER = ['claude', 'droid', 'zcode', 'codex', 'opencode'] as const;
-
 export function combineSources(sources: Set<string | undefined>): string {
 	const atoms = new Set<string>();
 	for (const source of sources) {


### PR DESCRIPTION
## Summary

The `sourceSchema` valibot picklist hardcoded all 31 non-empty subsets of the 5 known sources (`claude/droid/zcode/codex/opencode`). Every new source would double that list (\u2192 63, 127, \u2026), making it error-prone to maintain by hand.

This is a **behavior-preserving refactor** and a prerequisite for adding `devin` + `pi` sources (follow-up PRs).

## Changes

- **`_consts.ts`**: `SOURCE_ORDER` is now the single source of truth (moved from `data-loader.ts`). New `generateSourceSubsets()` recursively enumerates all non-empty ordered subsets joined by `/`, exposed as `SOURCE_SUBSETS`.
- **`_types.ts`**: `sourceSchema` now uses `v.picklist(SOURCE_SUBSETS)` instead of the hand-written 31-entry list.
- **`data-loader.ts`**: imports `SOURCE_ORDER` from `_consts.ts` (removed local definition).

## Verification

- The generated 31 entries are **byte-identical** to the previous hand-written list (verified via standalone node script: same entries, same order).
- `pnpm --filter='better-ccusage' typecheck`: clean
- `pnpm --filter='better-ccusage' test`: **304 passed**
- `pnpm --filter='better-ccusage' lint`: clean
- No circular imports (`_consts.ts` \u2190 `_types.ts` \u2190 `data-loader.ts`; `_consts.ts` imports only node + xdg).

## Type precision note

The branded `Source` type widens from a 31-literal union to `string & Brand<'Source'>` because the generated array is not a literal tuple. This is acceptable: no consumer relied on literal narrowing (verified by grepping for `switch (source)`, `Record<Source,\u2026>`, `keyof Source`, etc. \u2014 zero matches outside `_types.ts`), and the validation boundary stays exact at runtime (the picklist still rejects invalid values). Documented in the `generateSourceSubsets` doc comment.

Adding `devin` or `pi` later is now a one-line change to `SOURCE_ORDER`.

## Refs
Prep for upstream ccusage PRs [#1398](https://github.com/ccusage/ccusage/pull/1398) (devin) and [#1338](https://github.com/ccusage/ccusage/pull/1338) (pi/omp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized how usage data sources are combined and represented across the application.
  * Added support for all valid non-empty source combinations in a consistent order.
  * Preserved existing behavior by defaulting unspecified source selections to Claude.
* **Documentation**
  * Clarified source-combination behavior and ordering for improved transparency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->