### PR TITLE
feat(pi): add pi / oh-my-pi usage adapter with omp auto-detection

### DIFF
--- a/apps/better-ccusage/README.md
+++ b/apps/better-ccusage/README.md
@@ -35,9 +35,9 @@ better-ccusage maintains full compatibility with ccusage while adding comprehens
 
 ## better-ccusage Family
 
-### 📊 [better-ccusage](https://www.npmjs.com/package/better-ccusage) - Enhanced Claude Code/Droid/ZCode/Codex/OpenCode/Devin Usage Analyzer with Multi-Provider Support
+### 📊 [better-ccusage](https://www.npmjs.com/package/better-ccusage) - Enhanced Claude Code/Droid/ZCode/Codex/OpenCode/Devin/pi Usage Analyzer with Multi-Provider Support
 
-The main CLI tool for analyzing Claude Code, Droid, ZCode, OpenAI Codex, OpenCode, and Devin usage from local JSONL/SQLite files with support for multiple AI providers including Anthropic, Zai, and all GLM models (including GLM-5-Turbo, GLM-5.2), kat-coder models. Track daily, weekly, monthly, and session-based usage with beautiful tables and live monitoring. ZCode usage is read directly from its SQLite database (`~/.zcode/cli/db/db.sqlite`), Codex usage from `~/.codex/sessions`, OpenCode usage from `~/.local/share/opencode/opencode.db`, and Devin usage from ATIF transcripts under `~/.local/share/devin/cli/transcripts/` (enriched by `sessions.db`).
+The main CLI tool for analyzing Claude Code, Droid, ZCode, OpenAI Codex, OpenCode, Devin, and pi/oh-my-pi usage from local JSONL/SQLite files with support for multiple AI providers including Anthropic, Zai, and all GLM models (including GLM-5-Turbo, GLM-5.2), kat-coder models. Track daily, weekly, monthly, and session-based usage with beautiful tables and live monitoring. ZCode usage is read directly from its SQLite database (`~/.zcode/cli/db/db.sqlite`), Codex usage from `~/.codex/sessions`, OpenCode usage from `~/.local/share/opencode/opencode.db`, Devin usage from ATIF transcripts under `~/.local/share/devin/cli/transcripts/` (enriched by `sessions.db`), and pi/oh-my-pi usage from JSONL sessions under `~/.pi/agent/sessions` and `~/.omp/agent/sessions` (auto-detected).
 
 > 💡 The standalone `@better-ccusage/codex` and `@better-ccusage/opencode` packages are now deprecated forwarders — Codex and OpenCode support is built directly into `better-ccusage`. Run `npx better-ccusage` to see all sources in one report.
 

--- a/apps/better-ccusage/README.md
+++ b/apps/better-ccusage/README.md
@@ -17,21 +17,36 @@
     <img src="https://cdn.jsdelivr.net/gh/cobra91/better-ccusage@main/docs/public/screenshot.png">
 </div>
 
-> Analyze your Claude Code, Droid, ZCode, Codex, OpenCode, and Devin token usage and costs from local JSONL/SQLite files with multi-provider support — incredibly fast and informative!
+> Analyze your Claude Code, Droid, ZCode, Codex, OpenCode, Devin, and pi/oh-my-pi token usage and costs from local JSONL/SQLite files with multi-provider support — incredibly fast and informative!
 
 ## About better-ccusage
 
-**better-ccusage** is a fork of the original ccusage project that addresses a critical limitation: while ccusage focuses exclusively on Claude Code usage with Anthropic models, better-ccusage extends support to external providers that use Claude Code with different providers like Anthropic, Zai, Dashscope and many models like GLM series from Zai, kat-coder from Kwaipilot, kimi from Moonshot, Minimax, sonnet-4, sonnet-4.5 and Qwen-Max etc.
+**better-ccusage** is an enhanced fork of the [ccusage](https://github.com/ccusage/ccusage) project. It aggregates token usage and costs across **seven local AI coding tools** into a single report, with broad multi-provider pricing support.
 
-### Why the Fork?
+### Supported data sources
 
-The original ccusage project is designed specifically for Anthropic's Claude Code and doesn't account for:
+better-ccusage reads usage data directly from each tool's local files (JSONL or SQLite), auto-detected from their default locations:
 
-- **Zai** providers that use Claude Code infrastructure with their own models
-- **All GLM models (including GLM-5-Turbo), kat-coder, minimax, moonshot** models from other AI providers
-- Multi-provider environments where organizations use different AI services through Claude Code
+| Source     | Tool                                                                                 | Data location                                                             |
+| ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `claude`   | [Claude Code](https://claude.com/claude-code)                                        | `~/.claude/projects/` (JSONL)                                             |
+| `droid`    | [Factory Droid](https://factory.ai)                                                  | `~/.factory/sessions/` (JSONL)                                            |
+| `zcode`    | [ZCode](https://z.ai) (Zai's coding tool)                                            | `~/.zcode/cli/db/db.sqlite`                                               |
+| `codex`    | [OpenAI Codex CLI](https://github.com/openai/codex)                                  | `~/.codex/sessions/` (JSONL)                                              |
+| `opencode` | [OpenCode](https://github.com/sst/opencode)                                          | `~/.local/share/opencode/opencode.db`                                     |
+| `devin`    | [Devin](https://devin.ai) (Cognition)                                                | `~/.local/share/devin/cli/transcripts/` + `sessions.db`                   |
+| `pi`       | [pi](https://github.com/anthropics/pi) + [oh-my-pi](https://github.com/oh-my-pi/omp) | `~/.pi/agent/sessions/` + `~/.omp/agent/sessions/` (auto-detected, JSONL) |
 
-better-ccusage maintains full compatibility with ccusage while adding comprehensive support for these additional providers and models.
+Filter to a single source with the positional syntax: `better-ccusage <source> <report>` (e.g. `better-ccusage devin daily`).
+
+### Why the fork?
+
+The original ccusage project focused exclusively on Claude Code usage with Anthropic models. better-ccusage extends this in two directions:
+
+- **Multi-source**: added ZCode (SQLite), Droid, OpenAI Codex, OpenCode, Devin, and pi/oh-my-pi on top of Claude Code — all aggregated in one report. (Devin and pi are ported from upstream ccusage's open PRs [#1398](https://github.com/ccusage/ccusage/pull/1398) and [#1338](https://github.com/ccusage/ccusage/pull/1338); better-ccusage ships them ahead of upstream.)
+- **Multi-provider pricing**: accurate cost calculation for external providers that run Claude Code with their own models — Anthropic, Zai (all GLM models including GLM-5-Turbo, GLM-5.2), Dashscope, Kwaipilot (kat-coder), Moonshot (kimi), Minimax, Qwen-Max, and more.
+
+> **Note:** better-ccusage and upstream ccusage have diverged significantly in architecture and scope. better-ccusage is a TypeScript monorepo; upstream ccusage is a Rust workspace. They are maintained independently — feature ports go in both directions but are not kept in lockstep.
 
 ## better-ccusage Family
 
@@ -110,13 +125,14 @@ npx better-ccusage daily --instances --project myproject --json  # Combined usag
 npx better-ccusage --compact  # Force compact table mode
 npx better-ccusage monthly --compact  # Compact monthly report
 
-# Focus on a single data source (Claude, Droid, ZCode, Codex, OpenCode, Devin)
+# Focus on a single data source (Claude, Droid, ZCode, Codex, OpenCode, Devin, pi)
 # By default every report aggregates all detected sources. Prefix the command
 # with a source name to see usage for that tool only:
 npx better-ccusage codex daily          # Codex-only daily report
 npx better-ccusage opencode blocks      # OpenCode-only billing blocks
 npx better-ccusage droid session        # Droid-only session report
 npx better-ccusage devin daily          # Devin-only daily report
+npx better-ccusage pi daily             # pi/oh-my-pi-only daily report
 npx better-ccusage zcode monthly        # ZCode-only monthly report
 npx better-ccusage codex                # shorthand for "codex daily"
 # Equivalent explicit form (the positional form above is preferred):

--- a/apps/better-ccusage/src/_consts.ts
+++ b/apps/better-ccusage/src/_consts.ts
@@ -52,7 +52,7 @@ const XDG_CONFIG_DIR = xdgConfig ?? path.join(USER_HOME_DIR, '.config');
  * `sourceSchema` picklist (via `SOURCE_SUBSETS`). Add a new source here and
  * both the combiner and the schema pick up the extra atom automatically.
  */
-export const SOURCE_ORDER = ['claude', 'droid', 'zcode', 'codex', 'opencode', 'devin'] as const;
+export const SOURCE_ORDER = ['claude', 'droid', 'zcode', 'codex', 'opencode', 'devin', 'pi'] as const;
 
 /**
  * Display labels for each source atom, matching the canonical capitalization
@@ -235,6 +235,33 @@ export const DEVIN_SESSIONS_DB_SUBPATH = 'sessions.db';
  * JSON file glob pattern for finding Devin ATIF transcript files (recursive).
  */
 export const DEVIN_TRANSCRIPT_GLOB = '**/*.json';
+
+/**
+ * Environment variable for overriding the pi-agent sessions directory.
+ *
+ * Supports a comma-separated list of directories. When set, only the listed
+ * directories are scanned (the default pi/omp auto-detection is skipped).
+ */
+export const PI_AGENT_DIR_ENV = 'PI_AGENT_DIR';
+
+/**
+ * Default pi-agent sessions directory: `~/.pi/agent/sessions`.
+ */
+export const DEFAULT_PI_SESSIONS_PATH = path.join('.pi', 'agent', 'sessions');
+
+/**
+ * Default oh-my-pi (omp) sessions directory: `~/.omp/agent/sessions`.
+ *
+ * omp is a widely used pi fork that writes the same JSONL session format.
+ * Auto-detected alongside the pi default when neither `PI_AGENT_DIR` nor a
+ * custom path is set (matches upstream ccusage PR ccusage/ccusage#1338).
+ */
+export const DEFAULT_OMP_SESSIONS_PATH = path.join('.omp', 'agent', 'sessions');
+
+/**
+ * JSONL file glob pattern for finding pi/omp session files (recursive).
+ */
+export const PI_SESSION_GLOB = '**/*.jsonl';
 
 /**
  * Claude projects directory name within the data directory

--- a/apps/better-ccusage/src/data-loader.ts
+++ b/apps/better-ccusage/src/data-loader.ts
@@ -72,6 +72,7 @@ import { getDevinPath, processDevinSessions } from './devin-adapter.ts';
 import { getDroidPath, processDroidSessions } from './droid-adapter.ts';
 import { logger } from './logger.ts';
 import { getOpenCodeDbPath, processOpenCodeSessions } from './opencode-adapter.ts';
+import { getPiPaths, processPiSessions } from './pi-adapter.ts';
 import { getZcodeDbPath, processZcodeSessions } from './zcode-adapter.ts';
 
 /**
@@ -906,7 +907,23 @@ export async function loadDailyUsageData(
 		}
 	}
 
-	if (fileList.length === 0 && droidEntries.length === 0 && zcodeEntries.length === 0 && codexEntries.length === 0 && opencodeEntries.length === 0 && devinEntries.length === 0) {
+	// Also load pi/oh-my-pi usage from its JSONL sessions if available
+	const piPaths = getPiPaths();
+	logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
+	let piEntries: UsageData[] = [];
+	if (piPaths.length === 0 || (piPaths.length === 1 && piPaths[0] === '')) {
+		logger.debug('Pi sessions paths are empty');
+	}
+	else {
+		try {
+			piEntries = await processPiSessions(piPaths, options);
+		}
+		catch (error) {
+			logger.warn(`Failed to load pi sessions: ${String(error)}`);
+		}
+	}
+
+	if (fileList.length === 0 && droidEntries.length === 0 && zcodeEntries.length === 0 && codexEntries.length === 0 && opencodeEntries.length === 0 && devinEntries.length === 0 && piEntries.length === 0) {
 		return [];
 	}
 
@@ -1111,6 +1128,30 @@ export async function loadDailyUsageData(
 		});
 	}
 
+	// Add pi entries to the collection
+	for (const piData of piEntries) {
+		piData.source ??= createSource('pi');
+
+		const uniqueHash = createUniqueHash(piData);
+		if (isDuplicateEntry(uniqueHash, processedHashes)) {
+			continue;
+		}
+		markAsProcessed(uniqueHash, processedHashes);
+
+		const date = formatDate(piData.timestamp, options?.timezone, DEFAULT_LOCALE);
+		const cost = fetcher == null
+			? piData.costUSD ?? 0
+			: await calculateCostForEntry(piData, mode, fetcher);
+
+		allEntries.push({
+			data: piData,
+			date,
+			cost,
+			model: piData.message.model,
+			project: piData.cwd ?? path.join('pi', 'unknown'),
+		});
+	}
+
 	// Group by date, optionally including project
 	// This will combine Claude and droid entries from the same date
 	// Automatically enable project grouping when project filter is specified
@@ -1293,7 +1334,23 @@ export async function loadSessionData(
 		}
 	}
 
-	if (filesWithBase.length === 0 && droidEntries.length === 0 && zcodeEntries.length === 0 && codexEntries.length === 0 && opencodeEntries.length === 0 && devinEntries.length === 0) {
+	// Also load pi/oh-my-pi usage from its JSONL sessions if available
+	const piPaths = getPiPaths();
+	logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
+	let piEntries: UsageData[] = [];
+	if (piPaths.length === 0 || (piPaths.length === 1 && piPaths[0] === '')) {
+		logger.debug('Pi sessions paths are empty');
+	}
+	else {
+		try {
+			piEntries = await processPiSessions(piPaths, options);
+		}
+		catch (error) {
+			logger.warn(`Failed to load pi sessions: ${String(error)}`);
+		}
+	}
+
+	if (filesWithBase.length === 0 && droidEntries.length === 0 && zcodeEntries.length === 0 && codexEntries.length === 0 && opencodeEntries.length === 0 && devinEntries.length === 0 && piEntries.length === 0) {
 		return [];
 	}
 
@@ -1489,6 +1546,26 @@ export async function loadSessionData(
 			cost,
 			timestamp: devinData.timestamp,
 			model: devinData.message.model,
+		});
+	}
+
+	// Add pi entries to the collection
+	for (const piData of piEntries) {
+		piData.source ??= createSource('pi');
+
+		const sessionKey = path.join('pi', piData.sessionId ?? 'unknown-session');
+		const cost = fetcher == null
+			? piData.costUSD ?? 0
+			: await calculateCostForEntry(piData, mode, fetcher);
+
+		allEntries.push({
+			data: piData,
+			sessionKey,
+			sessionId: piData.sessionId ?? 'unknown-session',
+			projectPath: piData.cwd ?? path.join('pi', 'unknown'),
+			cost,
+			timestamp: piData.timestamp,
+			model: piData.message.model,
 		});
 	}
 
@@ -2159,8 +2236,37 @@ export async function loadSessionBlockData(
 		}
 	}
 
+	// Also load pi/oh-my-pi usage from its JSONL sessions if available
+	const piPaths = getPiPaths();
+	logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
+	let piEntries: LoadedUsageEntry[] = [];
+	if (piPaths.length > 0 && !(piPaths.length === 1 && piPaths[0] === '')) {
+		try {
+			const rawPiEntries = await processPiSessions(piPaths, options);
+			piEntries = await Promise.all(rawPiEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
+				timestamp: new Date(entry.timestamp),
+				usage: {
+					inputTokens: entry.message.usage.input_tokens,
+					outputTokens: entry.message.usage.output_tokens,
+					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+				},
+				costUSD: fetcher == null
+					? entry.costUSD ?? 0
+					: await calculateCostForEntry(entry, mode, fetcher),
+				model: entry.message.model ?? 'unknown',
+				version: entry.version ?? undefined,
+				usageLimitResetTime: undefined,
+				source: entry.source ?? 'pi',
+			})));
+		}
+		catch (error) {
+			logger.warn(`Failed to load pi sessions: ${String(error)}`);
+		}
+	}
+
 	// Combine Claude, droid, zcode, codex, and opencode entries
-	const combinedEntries = [...allEntries, ...droidEntries, ...zcodeEntries, ...codexEntries, ...opencodeEntries, ...devinEntries];
+	const combinedEntries = [...allEntries, ...droidEntries, ...zcodeEntries, ...codexEntries, ...opencodeEntries, ...devinEntries, ...piEntries];
 
 	// Identify session blocks
 	const blocks = identifySessionBlocks(combinedEntries, allUserMessages, options?.sessionDurationHours);

--- a/apps/better-ccusage/src/data-loader.ts
+++ b/apps/better-ccusage/src/data-loader.ts
@@ -908,18 +908,20 @@ export async function loadDailyUsageData(
 	}
 
 	// Also load pi/oh-my-pi usage from its JSONL sessions if available
-	const piPaths = getPiPaths();
-	logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
 	let piEntries: UsageData[] = [];
-	if (piPaths.length === 0 || (piPaths.length === 1 && piPaths[0] === '')) {
-		logger.debug('Pi sessions paths are empty');
-	}
-	else {
-		try {
-			piEntries = await processPiSessions(piPaths, options);
+	if (sourceFilter == null || sourceFilter === 'pi') {
+		const piPaths = getPiPaths();
+		logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
+		if (piPaths.length === 0 || (piPaths.length === 1 && piPaths[0] === '')) {
+			logger.debug('Pi sessions paths are empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load pi sessions: ${String(error)}`);
+		else {
+			try {
+				piEntries = await processPiSessions(piPaths, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load pi sessions: ${String(error)}`);
+			}
 		}
 	}
 
@@ -1335,18 +1337,20 @@ export async function loadSessionData(
 	}
 
 	// Also load pi/oh-my-pi usage from its JSONL sessions if available
-	const piPaths = getPiPaths();
-	logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
 	let piEntries: UsageData[] = [];
-	if (piPaths.length === 0 || (piPaths.length === 1 && piPaths[0] === '')) {
-		logger.debug('Pi sessions paths are empty');
-	}
-	else {
-		try {
-			piEntries = await processPiSessions(piPaths, options);
+	if (sourceFilter == null || sourceFilter === 'pi') {
+		const piPaths = getPiPaths();
+		logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
+		if (piPaths.length === 0 || (piPaths.length === 1 && piPaths[0] === '')) {
+			logger.debug('Pi sessions paths are empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load pi sessions: ${String(error)}`);
+		else {
+			try {
+				piEntries = await processPiSessions(piPaths, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load pi sessions: ${String(error)}`);
+			}
 		}
 	}
 
@@ -2237,31 +2241,33 @@ export async function loadSessionBlockData(
 	}
 
 	// Also load pi/oh-my-pi usage from its JSONL sessions if available
-	const piPaths = getPiPaths();
-	logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
 	let piEntries: LoadedUsageEntry[] = [];
-	if (piPaths.length > 0 && !(piPaths.length === 1 && piPaths[0] === '')) {
-		try {
-			const rawPiEntries = await processPiSessions(piPaths, options);
-			piEntries = await Promise.all(rawPiEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
-				timestamp: new Date(entry.timestamp),
-				usage: {
-					inputTokens: entry.message.usage.input_tokens,
-					outputTokens: entry.message.usage.output_tokens,
-					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
-					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
-				},
-				costUSD: fetcher == null
-					? entry.costUSD ?? 0
-					: await calculateCostForEntry(entry, mode, fetcher),
-				model: entry.message.model ?? 'unknown',
-				version: entry.version ?? undefined,
-				usageLimitResetTime: undefined,
-				source: entry.source ?? 'pi',
-			})));
-		}
-		catch (error) {
-			logger.warn(`Failed to load pi sessions: ${String(error)}`);
+	if (sourceFilter == null || sourceFilter === 'pi') {
+		const piPaths = getPiPaths();
+		logger.debug(`Pi sessions paths: ${piPaths.join(', ')}`);
+		if (piPaths.length > 0 && !(piPaths.length === 1 && piPaths[0] === '')) {
+			try {
+				const rawPiEntries = await processPiSessions(piPaths, options);
+				piEntries = await Promise.all(rawPiEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
+					timestamp: new Date(entry.timestamp),
+					usage: {
+						inputTokens: entry.message.usage.input_tokens,
+						outputTokens: entry.message.usage.output_tokens,
+						cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+						cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+					},
+					costUSD: fetcher == null
+						? entry.costUSD ?? 0
+						: await calculateCostForEntry(entry, mode, fetcher),
+					model: entry.message.model ?? 'unknown',
+					version: entry.version ?? undefined,
+					usageLimitResetTime: undefined,
+					source: entry.source ?? 'pi',
+				})));
+			}
+			catch (error) {
+				logger.warn(`Failed to load pi sessions: ${String(error)}`);
+			}
 		}
 	}
 

--- a/apps/better-ccusage/src/pi-adapter.ts
+++ b/apps/better-ccusage/src/pi-adapter.ts
@@ -1,0 +1,671 @@
+/**
+ * @fileoverview pi-agent (and oh-my-pi) data adapter.
+ *
+ * Reads the JSONL session files that pi and its widely used fork oh-my-pi
+ * (omp) write under `~/.pi/agent/sessions` and `~/.omp/agent/sessions`
+ * respectively, and normalizes each assistant message that carries token
+ * usage into the shared {@link UsageData} shape so the unified
+ * better-ccusage loaders can aggregate it alongside the other sources.
+ *
+ * Both directories are auto-detected when neither `PI_AGENT_DIR` nor a custom
+ * path is set (matches upstream ccusage PR ccusage/ccusage#1338). Entries are
+ * deduplicated by the loader's `createUniqueHash`, so a session file present
+ * in both directories is counted once.
+ *
+ * Cost handling: pi writes a per-message `cost.total` (USD). We emit it as
+ * `costUSD` so the `auto` cost mode (the default) uses it directly; the
+ * `calculate` mode still recomputes from tokens via the shared engine.
+ *
+ * Token handling is additive (the Claude model): the four buckets
+ * (input/output/cache-read/cache-write) are independent and summed, with no
+ * subtraction of cached tokens from input (unlike Codex). When
+ * `totalTokens` exceeds the sum of the known buckets, the surplus is folded
+ * into `output_tokens` (when output is 0) — matches upstream's
+ * `apply_total_token_fallback`.
+ *
+ * Per the upstream omp PR, models are NOT prefixed (`[pi]`/`[omp]`): both
+ * default directories share the same `pi` source label and the same pricing
+ * lookup.
+ *
+ * @module pi-adapter
+ */
+
+import type { LoadOptions, UsageData } from './data-loader.ts';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { createFixture } from 'fs-fixture';
+import { glob } from 'tinyglobby';
+import * as v from 'valibot';
+import {
+	DEFAULT_OMP_SESSIONS_PATH,
+	DEFAULT_PI_SESSIONS_PATH,
+	PI_AGENT_DIR_ENV,
+	PI_SESSION_GLOB,
+	USER_HOME_DIR,
+} from './_consts.ts';
+import {
+	createISOTimestamp,
+	createMessageId,
+	createModelName,
+	createRequestId,
+	createSessionId,
+	createSource,
+	createVersion,
+} from './_types.ts';
+import { logger } from './logger.ts';
+
+/**
+ * First non-empty trimmed string in a list; `undefined` if none.
+ */
+function firstNonEmpty(values: Array<string | null | undefined>): string | undefined {
+	for (const value of values) {
+		if (value == null) {
+			continue;
+		}
+		const trimmed = value.trim();
+		if (trimmed !== '') {
+			return trimmed;
+		}
+	}
+	return undefined;
+}
+
+// --- pi JSONL valibot schemas --------------------------------------------
+
+/**
+ * A message's cost blob. pi writes `cost.total` (USD); the object form is
+ * normalized, a non-object `cost` (e.g. `0`) yields `undefined`.
+ */
+const piCostSchema = v.optional(
+	v.union([
+		v.object({ total: v.optional(v.number()) }),
+		v.unknown(),
+	]),
+);
+
+const piUsageSchema = v.object({
+	input: v.optional(v.number(), 0),
+	output: v.optional(v.number(), 0),
+	cacheRead: v.optional(v.number(), 0),
+	cacheWrite: v.optional(v.number(), 0),
+	totalTokens: v.optional(v.number(), 0),
+	cost: piCostSchema,
+});
+
+const piMessageSchema = v.object({
+	role: v.optional(v.string()),
+	model: v.optional(v.string()),
+	usage: v.optional(piUsageSchema),
+});
+
+const piLineSchema = v.object({
+	type: v.optional(v.string()),
+	timestamp: v.optional(v.string()),
+	message: v.optional(piMessageSchema),
+});
+
+/**
+ * Extract the display cost (USD) from a pi `cost` field. Accepts the object
+ * form `{ total }`; anything else returns `undefined`.
+ */
+function extractCost(cost: unknown): number | undefined {
+	if (cost == null || typeof cost !== 'object') {
+		return undefined;
+	}
+	const total = (cost as Record<string, unknown>).total;
+	return typeof total === 'number' ? total : undefined;
+}
+
+/**
+ * Apply upstream's `apply_total_token_fallback`: if `totalTokens` exceeds the
+ * sum of the known buckets, fold the missing tokens into `output` (when
+ * output is 0), else drop them (they are accounted as an unpriced surplus).
+ * Returns the possibly-adjusted token buckets.
+ */
+function applyTotalTokenFallback(usage: {
+	input: number;
+	output: number;
+	cacheCreation: number;
+	cacheRead: number;
+}, totalTokens: number): { input: number; output: number; cacheCreation: number; cacheRead: number } {
+	const known = usage.input + usage.output + usage.cacheCreation + usage.cacheRead;
+	const missing = totalTokens > known ? totalTokens - known : 0;
+	if (missing === 0) {
+		return usage;
+	}
+	if (usage.output === 0) {
+		return { ...usage, output: missing };
+	}
+	// Non-zero output: surplus tokens are an unpriced extra (upstream tracks
+	// them as `extra_total_tokens`); we leave the billable buckets unchanged.
+	return usage;
+}
+
+/**
+ * Total tokens across the four buckets. Matches upstream's
+ * `total_usage_tokens`. Used to skip zero-token messages.
+ */
+function totalUsageTokens(usage: {
+	input: number;
+	output: number;
+	cacheCreation: number;
+	cacheRead: number;
+}): number {
+	return usage.input + usage.output + usage.cacheCreation + usage.cacheRead;
+}
+
+// --- path resolution -----------------------------------------------------
+
+/**
+ * Get the pi/omp sessions directories to scan.
+ *
+ * Resolution order (mirrors upstream `pi/paths.rs` + PR #1338):
+ * 1. `PI_AGENT_DIR` env var (comma-separated list of explicit dirs)
+ * 2. Sentinel `['']` under VITEST (signals callers to skip the source)
+ * 3. Default: scan both `~/.pi/agent/sessions` AND `~/.omp/agent/sessions`,
+ *    keeping only those that exist on disk. Order is `.pi` then `.omp`.
+ *
+ * Unlike the single-path adapters (codex/devin), this returns an array
+ * because omp auto-detection scans two directories.
+ */
+export function getPiPaths(): string[] {
+	const envDir = process.env[PI_AGENT_DIR_ENV]?.trim();
+	if (envDir != null && envDir !== '') {
+		return envDir
+			.split(',')
+			.map(p => p.trim())
+			.filter(p => p !== '')
+			.map(p => path.resolve(p));
+	}
+
+	if (process.env.VITEST != null) {
+		return [''];
+	}
+
+	const candidates = [
+		path.join(USER_HOME_DIR, DEFAULT_PI_SESSIONS_PATH),
+		path.join(USER_HOME_DIR, DEFAULT_OMP_SESSIONS_PATH),
+	];
+	return candidates.filter(p => existsSync(p));
+}
+
+// --- per-file parsing ----------------------------------------------------
+
+/**
+ * Extract the session id from a session file path. Matches upstream's
+ * `extract_session_id`: split the filename stem on the first `_` and take
+ * the part after (e.g. `agent_abc123.jsonl` -> `abc123`); if no `_`, use
+ * the whole stem.
+ */
+function extractSessionId(filePath: string): string {
+	const stem = path.basename(filePath, path.extname(filePath));
+	const underscoreIndex = stem.indexOf('_');
+	return underscoreIndex >= 0 ? stem.slice(underscoreIndex + 1) : stem;
+}
+
+/**
+ * Extract the project label from a session file path. Matches upstream's
+ * `extract_project`: the path component immediately after the first
+ * `sessions` component; `"unknown"` if none.
+ *
+ * The path is normalized to the OS separator first because `tinyglobby`
+ * returns forward-slash paths even on Windows.
+ */
+function extractProject(filePath: string): string {
+	const parts = path.normalize(filePath).split(path.sep);
+	const sessionsIndex = parts.indexOf('sessions');
+	if (sessionsIndex >= 0 && sessionsIndex + 1 < parts.length) {
+		const next = parts[sessionsIndex + 1];
+		if (next !== undefined && next !== '') {
+			return next;
+		}
+	}
+	return 'unknown';
+}
+
+/**
+ * Whether a parsed pi line should be accepted as a billable message.
+ * Matches upstream's `is_pi_message_usage`: keep when `type` is absent or
+ * `"message"`, AND `message.role === "assistant"`, AND `message.usage` is
+ * present.
+ */
+function isBillableMessage(line: v.InferOutput<typeof piLineSchema>): boolean {
+	if (line.type != null && line.type !== 'message') {
+		return false;
+	}
+	if (line.message == null) {
+		return false;
+	}
+	if (line.message.role !== 'assistant') {
+		return false;
+	}
+	return line.message.usage != null;
+}
+
+// --- main entry point ----------------------------------------------------
+
+/**
+ * Read every JSONL session file under the given directories and transform
+ * each billable assistant message into a {@link UsageData} entry.
+ *
+ * @param dirs - Absolute session directories to scan (typically the pi +
+ * omp defaults, or a custom list from `PI_AGENT_DIR`)
+ * @param _options - Load options (kept for parity with the other adapters)
+ * @returns Transformed usage entries (one per billable assistant message)
+ */
+export async function processPiSessions(
+	dirs: string[],
+	_options: LoadOptions = {},
+): Promise<UsageData[]> {
+	const results: UsageData[] = [];
+	for (const dir of dirs) {
+		if (dir === '') {
+			logger.debug('Pi sessions directory is empty, skipping');
+			continue;
+		}
+		if (!existsSync(dir)) {
+			logger.debug(`Pi sessions directory not found at ${dir}`);
+			continue;
+		}
+
+		const files = await glob(PI_SESSION_GLOB, {
+			cwd: dir,
+			absolute: true,
+		});
+
+		for (const file of files) {
+			let content: string;
+			try {
+				content = await readFile(file, 'utf-8');
+			}
+			catch (error) {
+				logger.debug(`Failed to read pi session ${file}: ${String(error)}`);
+				continue;
+			}
+
+			const sessionId = extractSessionId(file);
+			const project = extractProject(file);
+
+			const lines = content.split('\n');
+			for (const line of lines) {
+				// Cheap prefilter: skip lines lacking the substrings we need
+				// before paying for a JSON parse (matches upstream's
+				// `LinePrefilter::all(&[b'"usage"', b'"message"'])`).
+				if (!line.includes('"usage"') || !line.includes('"message"')) {
+					continue;
+				}
+
+				let parsed: unknown;
+				try {
+					parsed = JSON.parse(line);
+				}
+				catch {
+					continue;
+				}
+
+				const lineResult = v.safeParse(piLineSchema, parsed);
+				if (!lineResult.success) {
+					continue;
+				}
+				const piLine = lineResult.output;
+				if (!isBillableMessage(piLine)) {
+					continue;
+				}
+
+				// Non-null asserted: isBillableMessage guarantees message + usage.
+				const message = piLine.message!;
+				const piUsage = message.usage!;
+
+				// Resolve timestamp; skip if unparseable.
+				const timestamp = piLine.timestamp?.trim();
+				if (timestamp == null || timestamp === '') {
+					continue;
+				}
+				const parsedMs = Date.parse(timestamp);
+				if (Number.isNaN(parsedMs)) {
+					continue;
+				}
+				const isoTimestamp = new Date(parsedMs).toISOString();
+
+				const usage = applyTotalTokenFallback({
+					input: piUsage.input,
+					output: piUsage.output,
+					cacheCreation: piUsage.cacheWrite,
+					cacheRead: piUsage.cacheRead,
+				}, piUsage.totalTokens);
+				if (totalUsageTokens(usage) === 0) {
+					continue;
+				}
+
+				// Model: not prefixed (matches upstream omp PR #1338 — both .pi
+				// and .omp dirs share the `pi` source label and pricing lookup).
+				const modelRaw = firstNonEmpty([message.model]);
+				if (modelRaw === undefined) {
+					// Without a model we cannot price; skip rather than guess.
+					continue;
+				}
+
+				const costUSD = extractCost(piUsage.cost);
+				// Stable message id: line index within the file is not tracked
+				// here; dedup relies on the loader's createUniqueHash, which
+				// keys on message+request id. We synthesize a per-line id from
+				// the session id + timestamp + model + all four token buckets
+				// (matching upstream's entry_id shape) so two messages in the
+				// same session at the same instant with different buckets or
+				// models stay distinct instead of being collapsed.
+				const uniqueId = `${sessionId}#${isoTimestamp}#${modelRaw}#${usage.input}:${usage.output}:${usage.cacheRead}:${usage.cacheCreation}`;
+
+				const entry: UsageData = {
+					timestamp: createISOTimestamp(isoTimestamp),
+					sessionId: createSessionId(sessionId),
+					version: createVersion('1.0.0'),
+					message: {
+						usage: {
+							input_tokens: usage.input,
+							output_tokens: usage.output,
+							cache_creation_input_tokens: usage.cacheCreation,
+							cache_read_input_tokens: usage.cacheRead,
+						},
+						model: createModelName(modelRaw),
+						id: createMessageId(uniqueId),
+					},
+					// Additive token model (Claude): cached tokens are a separate
+					// bucket, not subtracted from input (unlike Codex).
+					costUSD,
+					requestId: createRequestId(uniqueId),
+					// Virtual cwd root so pi sessions are distinguishable, keyed
+					// by the project label derived from the path.
+					cwd: path.join('pi', project),
+					source: createSource('pi'),
+				};
+				results.push(entry);
+			}
+		}
+	}
+
+	logger.info(`Loaded ${results.length} pi usage entries from ${dirs.length} director${dirs.length === 1 ? 'y' : 'ies'}`);
+	return results;
+}
+
+if (import.meta.vitest != null) {
+	describe('processPiSessions', () => {
+		it('parses assistant messages with usage into UsageData (additive)', async () => {
+			await using fixture = await createFixture({
+				'agent_abc123.jsonl': [
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: {
+							role: 'assistant',
+							model: 'gpt-5.4',
+							usage: {
+								input: 1000,
+								output: 200,
+								cacheRead: 500,
+								cacheWrite: 50,
+								totalTokens: 1750,
+								cost: { total: 0.012 },
+							},
+						},
+					}),
+					// A user message: must be skipped.
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:05:00Z',
+						message: { role: 'user', model: 'gpt-5.4', usage: { input: 10 } },
+					}),
+					// A tool/event line: must be skipped (type != message).
+					JSON.stringify({
+						type: 'tool_call',
+						timestamp: '2026-07-03T10:10:00Z',
+						message: { role: 'assistant', usage: { input: 5 } },
+					}),
+				].join('\n'),
+			});
+
+			const results = await processPiSessions([fixture.path]);
+			expect(results).toHaveLength(1);
+			const entry = results[0]!;
+			expect(entry.source).toBe('pi');
+			expect(entry.sessionId).toBe('abc123');
+			expect(entry.message.model).toBe('gpt-5.4');
+			// Additive: all four buckets kept, no subtraction.
+			expect(entry.message.usage.input_tokens).toBe(1000);
+			expect(entry.message.usage.output_tokens).toBe(200);
+			expect(entry.message.usage.cache_creation_input_tokens).toBe(50);
+			expect(entry.message.usage.cache_read_input_tokens).toBe(500);
+			expect(entry.costUSD).toBeCloseTo(0.012);
+		});
+
+		it('applies totalTokens fallback: surplus goes to output when output is 0', async () => {
+			await using fixture = await createFixture({
+				'agent_tfb.jsonl': [
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: {
+							role: 'assistant',
+							model: 'm',
+							// Known sum = 1000, total = 1500 -> 500 missing, output 0 -> fold in.
+							usage: { input: 1000, output: 0, totalTokens: 1500 },
+						},
+					}),
+				].join('\n'),
+			});
+
+			const results = await processPiSessions([fixture.path]);
+			expect(results).toHaveLength(1);
+			expect(results[0]!.message.usage.output_tokens).toBe(500);
+			expect(results[0]!.message.usage.input_tokens).toBe(1000);
+		});
+
+		it('leaves non-zero output unchanged when totalTokens has a surplus', async () => {
+			await using fixture = await createFixture({
+				'agent_tfb2.jsonl': [
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: {
+							role: 'assistant',
+							model: 'm',
+							// Known sum = 300, total = 1000 -> 700 surplus, output != 0 -> dropped.
+							usage: { input: 200, output: 100, totalTokens: 1000 },
+						},
+					}),
+				].join('\n'),
+			});
+
+			const results = await processPiSessions([fixture.path]);
+			expect(results).toHaveLength(1);
+			expect(results[0]!.message.usage.input_tokens).toBe(200);
+			expect(results[0]!.message.usage.output_tokens).toBe(100);
+		});
+
+		it('handles non-object cost (e.g. cost: 0) without dropping the message', async () => {
+			await using fixture = await createFixture({
+				'agent_cost.jsonl': [
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: { role: 'assistant', model: 'm', usage: { input: 100, output: 50, cost: 0 } },
+					}),
+				].join('\n'),
+			});
+
+			const results = await processPiSessions([fixture.path]);
+			expect(results).toHaveLength(1);
+			expect(results[0]!.costUSD).toBeUndefined();
+		});
+
+		it('skips zero-token messages', async () => {
+			await using fixture = await createFixture({
+				'agent_zero.jsonl': [
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: { role: 'assistant', model: 'm', usage: { input: 0, output: 0 } },
+					}),
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:05:00Z',
+						message: { role: 'assistant', model: 'm', usage: { input: 10, output: 5 } },
+					}),
+				].join('\n'),
+			});
+
+			const results = await processPiSessions([fixture.path]);
+			expect(results).toHaveLength(1);
+			expect(results[0]!.message.usage.input_tokens).toBe(10);
+		});
+
+		it('skips messages without a model (cannot price, avoids mispricing)', async () => {
+			await using fixture = await createFixture({
+				'agent_nomodel.jsonl': [
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: { role: 'assistant', usage: { input: 50, output: 10 } },
+					}),
+				].join('\n'),
+			});
+
+			const results = await processPiSessions([fixture.path]);
+			expect(results).toHaveLength(0);
+		});
+
+		it('deduplicates omp vs pi: same file content in both dirs yields one entry set', async () => {
+			// Two separate fixture dirs with identical session content. The
+			// adapter emits from both, but the loader's createUniqueHash would
+			// collapse identical message+request ids. Here we verify the adapter
+			// itself is stable (same id for same content) so the loader dedup
+			// works: both entries share uniqueId -> collapsed downstream.
+			const record = JSON.stringify({
+				type: 'message',
+				timestamp: '2026-07-03T10:00:00Z',
+				message: { role: 'assistant', model: 'gpt-5.4', usage: { input: 100, output: 20 } },
+			});
+			await using fixture = await createFixture({
+				pi: { 'agent_shared.jsonl': record },
+				omp: { 'agent_shared.jsonl': record },
+			});
+
+			const results = await processPiSessions([`${fixture.path}/pi`, `${fixture.path}/omp`]);
+			// Adapter returns 2 (one per dir); they share the same uniqueId so
+			// the loader dedups them to 1 downstream.
+			expect(results).toHaveLength(2);
+			expect(results[0]!.message.id).toBe(results[1]!.message.id);
+			expect(results[0]!.source).toBe('pi');
+			expect(results[1]!.source).toBe('pi');
+		});
+
+		it('returns empty for the empty-path sentinel', async () => {
+			const results = await processPiSessions(['']);
+			expect(results).toEqual([]);
+		});
+
+		it('returns empty when the directory is missing', async () => {
+			const results = await processPiSessions(['/nonexistent/pi/path']);
+			expect(results).toEqual([]);
+		});
+
+		it('handles a malformed line without throwing', async () => {
+			await using fixture = await createFixture({
+				'agent_mixed.jsonl': [
+					'{ not valid json',
+					JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: { role: 'assistant', model: 'm', usage: { input: 1, output: 1 } },
+					}),
+				].join('\n'),
+			});
+
+			const results = await processPiSessions([fixture.path]);
+			expect(results).toHaveLength(1);
+		});
+
+		it('extracts session id and project from nested paths', async () => {
+			await using fixture = await createFixture({
+				sessions: {
+					myproject: {
+						'agent_xyz.jsonl': JSON.stringify({
+							type: 'message',
+							timestamp: '2026-07-03T10:00:00Z',
+							message: { role: 'assistant', model: 'm', usage: { input: 10, output: 5 } },
+						}),
+					},
+				},
+			});
+
+			const results = await processPiSessions([fixture.path]);
+			expect(results).toHaveLength(1);
+			expect(results[0]!.sessionId).toBe('xyz');
+			expect(results[0]!.cwd).toBe(path.join('pi', 'myproject'));
+		});
+	});
+
+	describe('getPiPaths', () => {
+		it('returns single-element empty array under VITEST when no env var is set', () => {
+			const original = process.env.PI_AGENT_DIR;
+			delete process.env.PI_AGENT_DIR;
+			try {
+				expect(getPiPaths()).toEqual(['']);
+			}
+			finally {
+				if (original !== undefined) {
+					process.env.PI_AGENT_DIR = original;
+				}
+			}
+		});
+
+		it('respects a single PI_AGENT_DIR', () => {
+			const original = process.env.PI_AGENT_DIR;
+			process.env.PI_AGENT_DIR = '/custom/pi';
+			try {
+				expect(getPiPaths()).toEqual([path.resolve('/custom/pi')]);
+			}
+			finally {
+				if (original === undefined) {
+					delete process.env.PI_AGENT_DIR;
+				}
+				else {
+					process.env.PI_AGENT_DIR = original;
+				}
+			}
+		});
+
+		it('splits a comma-separated PI_AGENT_DIR into multiple resolved paths', () => {
+			const original = process.env.PI_AGENT_DIR;
+			process.env.PI_AGENT_DIR = '/custom/pi,/custom/omp';
+			try {
+				expect(getPiPaths()).toEqual([path.resolve('/custom/pi'), path.resolve('/custom/omp')]);
+			}
+			finally {
+				if (original === undefined) {
+					delete process.env.PI_AGENT_DIR;
+				}
+				else {
+					process.env.PI_AGENT_DIR = original;
+				}
+			}
+		});
+	});
+
+	describe('applyTotalTokenFallback', () => {
+		it('returns usage unchanged when totalTokens <= known sum', () => {
+			const u = { input: 100, output: 50, cacheCreation: 10, cacheRead: 5 };
+			expect(applyTotalTokenFallback(u, 165)).toEqual(u);
+			expect(applyTotalTokenFallback(u, 100)).toEqual(u);
+		});
+		it('folds surplus into output when output is 0', () => {
+			const u = { input: 100, output: 0, cacheCreation: 0, cacheRead: 0 };
+			expect(applyTotalTokenFallback(u, 150).output).toBe(50);
+		});
+		it('leaves non-zero output unchanged on surplus', () => {
+			const u = { input: 100, output: 30, cacheCreation: 0, cacheRead: 0 };
+			expect(applyTotalTokenFallback(u, 200)).toEqual(u);
+		});
+	});
+}

--- a/apps/better-ccusage/src/pi-adapter.ts
+++ b/apps/better-ccusage/src/pi-adapter.ts
@@ -385,8 +385,31 @@ export async function processPiSessions(
 		}
 	}
 
-	logger.info(`Loaded ${results.length} pi usage entries from ${dirs.length} director${dirs.length === 1 ? 'y' : 'ies'}`);
-	return results;
+	// Deduplicate across scanned directories. pi auto-detection scans BOTH
+	// ~/.pi/agent/sessions and ~/.omp/agent/sessions, and a user may symlink or
+	// copy the same sessions into both — without this pass the same message
+	// would be counted twice in loadSessionData and loadSessionBlockData (whose
+	// non-Claude loops don't run the createUniqueHash gate). Key on the
+	// messageId (which already encodes sessionId + timestamp + model + token
+	// buckets), keeping the first occurrence.
+	const seen = new Set<string>();
+	const deduped: UsageData[] = [];
+	for (const entry of results) {
+		// message.id is always set (created via createMessageId above), but the
+		// branded type is optional under noUncheckedIndexedAccess; coerce to a
+		// plain string for the dedup key.
+		const key = entry.message.id ?? '';
+		if (key !== '' && seen.has(key)) {
+			continue;
+		}
+		if (key !== '') {
+			seen.add(key);
+		}
+		deduped.push(entry);
+	}
+
+	logger.info(`Loaded ${deduped.length} pi usage entries from ${dirs.length} director${dirs.length === 1 ? 'y' : 'ies'}${results.length !== deduped.length ? ` (${results.length - deduped.length} duplicate${results.length - deduped.length === 1 ? '' : 's'} dropped)` : ''}`);
+	return deduped;
 }
 
 if (import.meta.vitest != null) {
@@ -535,12 +558,11 @@ if (import.meta.vitest != null) {
 			expect(results).toHaveLength(0);
 		});
 
-		it('deduplicates omp vs pi: same file content in both dirs yields one entry set', async () => {
-			// Two separate fixture dirs with identical session content. The
-			// adapter emits from both, but the loader's createUniqueHash would
-			// collapse identical message+request ids. Here we verify the adapter
-			// itself is stable (same id for same content) so the loader dedup
-			// works: both entries share uniqueId -> collapsed downstream.
+		it('deduplicates omp vs pi: same file content in both dirs yields one entry', async () => {
+			// Two separate fixture dirs with identical session content. pi
+			// auto-detection scans both .pi and .omp, so the adapter deduplicates
+			// by message id (sessionId + timestamp + model + token buckets) to
+			// avoid double-counting. Same content in both dirs -> one entry.
 			const record = JSON.stringify({
 				type: 'message',
 				timestamp: '2026-07-03T10:00:00Z',
@@ -552,12 +574,34 @@ if (import.meta.vitest != null) {
 			});
 
 			const results = await processPiSessions([`${fixture.path}/pi`, `${fixture.path}/omp`]);
-			// Adapter returns 2 (one per dir); they share the same uniqueId so
-			// the loader dedups them to 1 downstream.
-			expect(results).toHaveLength(2);
-			expect(results[0]!.message.id).toBe(results[1]!.message.id);
+			// Same content in both dirs -> deduplicated to a single entry.
+			expect(results).toHaveLength(1);
 			expect(results[0]!.source).toBe('pi');
-			expect(results[1]!.source).toBe('pi');
+		});
+
+		it('keeps distinct sessions that happen to share a timestamp across dirs', async () => {
+			// Two dirs, two DIFFERENT sessions (different token counts) at the
+			// same instant — both must be kept (they are genuinely distinct).
+			await using fixture = await createFixture({
+				pi: {
+					'agent_a.jsonl': JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: { role: 'assistant', model: 'gpt-5.4', usage: { input: 100, output: 20 } },
+					}),
+				},
+				omp: {
+					'agent_b.jsonl': JSON.stringify({
+						type: 'message',
+						timestamp: '2026-07-03T10:00:00Z',
+						message: { role: 'assistant', model: 'gpt-5.4', usage: { input: 200, output: 40 } },
+					}),
+				},
+			});
+
+			const results = await processPiSessions([`${fixture.path}/pi`, `${fixture.path}/omp`]);
+			// Different sessions (different ids) -> both kept.
+			expect(results).toHaveLength(2);
 		});
 
 		it('returns empty for the empty-path sentinel', async () => {

--- a/apps/better-ccusage/src/pi-adapter.ts
+++ b/apps/better-ccusage/src/pi-adapter.ts
@@ -318,7 +318,7 @@ export async function processPiSessions(
 				const message = piLine.message!;
 				const piUsage = message.usage!;
 
-				// Resolve timestamp; skip if unparseable.
+				// Resolve timestamp; skip if unparsable.
 				const timestamp = piLine.timestamp?.trim();
 				if (timestamp == null || timestamp === '') {
 					continue;

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -76,6 +76,12 @@ export default defineConfig({
 					],
 				},
 				{
+					text: 'pi Source',
+					items: [
+						{ text: 'Overview', link: '/guide/pi' },
+					],
+				},
+				{
 					text: 'Configuration',
 					items: [
 						{ text: 'Overview', link: '/guide/configuration' },

--- a/docs/guide/devin.md
+++ b/docs/guide/devin.md
@@ -1,6 +1,6 @@
 # Devin Usage Tracking
 
-better-ccusage provides usage tracking for [Devin](https://devin.ai) (Cognition), reading the ATIF trajectory transcripts that the Devin CLI writes locally. This lets you monitor token usage and costs across your Devin sessions alongside Claude Code, Droid, ZCode, Codex, and OpenCode — all in one report.
+better-ccusage provides usage tracking for [Devin](https://devin.ai) (Cognition), reading the ATIF trajectory transcripts that the Devin CLI writes locally. This lets you monitor token usage and costs across your Devin sessions alongside Claude Code, Droid, ZCode, Codex, OpenCode, and pi/oh-my-pi — all in one report.
 
 Devin support is **built into `better-ccusage`** — there is no separate package to install.
 

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -143,6 +143,27 @@ When `DEVIN_DATA_DIR` is not set, better-ccusage automatically looks in:
 
 See the [Devin usage guide](/guide/devin.md) for details on token semantics, hidden-session filtering, and the ATIF transcript format.
 
+## PI_AGENT_DIR
+
+Specifies the pi/oh-my-pi (omp) sessions directory(ies) where better-ccusage should look for JSONL session files. Supports a comma-separated list for multiple directories.
+
+```bash
+# Single directory
+export PI_AGENT_DIR="/path/to/your/pi/sessions"
+better-ccusage daily
+
+# Multiple directories
+export PI_AGENT_DIR="/path/to/pi,/path/to/omp"
+better-ccusage daily
+```
+
+When `PI_AGENT_DIR` is not set, better-ccusage **auto-detects** both default directories (scanning whichever exist):
+
+- **pi**: `~/.pi/agent/sessions/`
+- **oh-my-pi (omp)**: `~/.omp/agent/sessions/`
+
+Setting `PI_AGENT_DIR` overrides auto-detection and scans only the listed directories. Entries are deduplicated, so a session present in both directories is counted once. See the [pi usage guide](/guide/pi.md) for details on token semantics and the JSONL format.
+
 ## LOG_LEVEL
 
 Controls the verbosity of log output. better-ccusage uses [consola](https://github.com/unjs/consola) for logging under the hood.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,11 +1,11 @@
 # Getting Started
 
-Welcome to better-ccusage! This guide will help you get up and running with analyzing your Claude Code/Droid/ZCode Usage data.
+Welcome to better-ccusage! This guide will help you get up and running with analyzing usage data from your local AI coding tools (Claude Code, Droid, ZCode, Codex, OpenCode, Devin, and pi/oh-my-pi).
 
 ## Prerequisites
 
-- Claude Code, Droid, or ZCode installed and used
-- Node.js 22.13+ or Bun runtime (ZCode usage requires Node.js 22.13+ for the built-in SQLite reader; Claude/Droid work on Node.js 20+)
+- At least one supported tool installed and used (Claude Code, Droid, ZCode, Codex, OpenCode, Devin, or pi/oh-my-pi)
+- Node.js 22.13+ or Bun runtime (ZCode/OpenCode/Devin usage requires Node.js 22.13+ for the built-in SQLite reader; the JSONL-only sources work on Node.js 20+)
 
 ## Quick Start
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,7 +2,7 @@
 
 ![better-ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**better-ccusage** (better-claude-code-usage) is a powerful CLI tool that analyzes your Claude Code/Droid/ZCode Usage from local files to help you understand your token consumption patterns and estimated costs with multi-provider support.
+**better-ccusage** (better-claude-code-usage) is a powerful CLI tool that analyzes token usage and estimated costs from **seven local AI coding tools** — Claude Code, Droid, ZCode, OpenAI Codex, OpenCode, Devin, and pi/oh-my-pi — aggregating them into a single report with multi-provider pricing support.
 
 ## The Problem
 
@@ -106,17 +106,14 @@ better-ccusage extends the original ccusage functionality with support for multi
 
 ## Why better-ccusage?
 
-better-ccusage was created to address a limitation in the original ccusage project: while ccusage focuses exclusively on Claude Code usage with Anthropic models, better-ccusage extends support to external tools/providers that use Claude Code/Droid/ZCode with different providers like Zai, Dashscope and many models like GLM-xx (including GLM-5.2), kat-coder, kimi, MiniMax etc.
+better-ccusage is an enhanced fork of the [ccusage](https://github.com/ccusage/ccusage) project, extending it in two directions:
 
-The original ccusage project doesn't account for:
+- **Multi-source**: aggregates usage from seven local AI coding tools — Claude Code, Droid, ZCode, OpenAI Codex, OpenCode, Devin, and pi/oh-my-pi — into a single report. Devin and pi are ported from upstream ccusage's open PRs ([#1398](https://github.com/ccusage/ccusage/pull/1398), [#1338](https://github.com/ccusage/ccusage/pull/1338)) and ship here ahead of upstream.
+- **Multi-provider pricing**: accurate cost calculation for providers that run these tools with their own models — Anthropic, **Zai** (all GLM models including GLM-5-Turbo, GLM-5.2), **Dashscope**, **Kwaipilot** (kat-coder), **Moonshot** (kimi), **MiniMax**, **Qwen-Max**, and more.
 
-- **Zai** providers that use Claude Code infrastructure with their own models
-- **GLM-xx, kat-coder** models from other AI providers
-- **Moonshot AI** (kimi) models like kimi-for-coding, kimi-researcher
-- **MiniMax** models like MiniMax-M2
-- Multi-provider environments where organizations use different AI services through Claude Code
-
-better-ccusage maintains full compatibility with ccusage while adding comprehensive support for these additional providers and models.
+::: tip Relationship to upstream ccusage
+better-ccusage and upstream ccusage have diverged significantly: better-ccusage is a TypeScript monorepo, upstream is a Rust workspace. They are maintained independently — feature ports go in both directions but are not kept in lockstep.
+:::
 
 ## Data Sources
 

--- a/docs/guide/pi.md
+++ b/docs/guide/pi.md
@@ -1,6 +1,6 @@
 # pi / oh-my-pi Usage Tracking
 
-better-ccusage provides usage tracking for [pi](https://github.com/anthropics/pi) and its widely used fork [oh-my-pi (omp)](https://github.com/oh-my-pi/omp), reading the JSONL session files both CLIs write locally. This lets you monitor token usage and costs across your pi/omp sessions alongside Claude Code, Droid, ZCode, Codex, OpenCode, and Devin — all in one report.
+better-ccusage provides usage tracking for **pi** and its widely used fork **oh-my-pi (omp)**, reading the JSONL session files both CLIs write locally. This lets you monitor token usage and costs across your pi/omp sessions alongside Claude Code, Droid, ZCode, Codex, OpenCode, and Devin — all in one report.
 
 pi/omp support is **built into `better-ccusage`** — there is no separate package to install.
 

--- a/docs/guide/pi.md
+++ b/docs/guide/pi.md
@@ -1,0 +1,92 @@
+# pi / oh-my-pi Usage Tracking
+
+better-ccusage provides usage tracking for [pi](https://github.com/anthropics/pi) and its widely used fork [oh-my-pi (omp)](https://github.com/oh-my-pi/omp), reading the JSONL session files both CLIs write locally. This lets you monitor token usage and costs across your pi/omp sessions alongside Claude Code, Droid, ZCode, Codex, OpenCode, and Devin — all in one report.
+
+pi/omp support is **built into `better-ccusage`** — there is no separate package to install.
+
+## Usage
+
+pi/omp usage is included automatically in every report. Run any standard command and pi/omp data (when present) appears alongside the other sources:
+
+```bash
+# Daily report (all sources, including pi/omp)
+npx better-ccusage daily
+
+# With per-model breakdown
+npx better-ccusage daily --breakdown
+
+# Monthly, compact mode
+npx better-ccusage monthly --compact
+
+# Session view
+npx better-ccusage session
+
+# Blocks (5-hour windows)
+npx better-ccusage blocks
+```
+
+The `Source` column in the output shows `pi` for entries parsed from pi/omp sessions.
+
+## Data Location
+
+Both CLIs write JSONL session files:
+
+- **pi**: `~/.pi/agent/sessions/**/*.jsonl`
+- **oh-my-pi (omp)**: `~/.omp/agent/sessions/**/*.jsonl`
+
+When neither `PI_AGENT_DIR` nor a custom path is set, better-ccusage **auto-detects both directories** and scans them together (matches upstream ccusage PR ccusage/ccusage#1338). Entries are deduplicated, so a session file present in both directories is counted once.
+
+### Custom Data Directory
+
+Override the scanned directories with the `PI_AGENT_DIR` environment variable (comma-separated for multiple):
+
+```bash
+# Single directory
+export PI_AGENT_DIR=/custom/pi/sessions
+npx better-ccusage daily
+
+# Multiple directories (comma-separated)
+export PI_AGENT_DIR=/custom/pi/sessions,/custom/omp/sessions
+npx better-ccusage daily
+```
+
+When `PI_AGENT_DIR` is set, the default pi/omp auto-detection is skipped and only the listed directories are scanned.
+
+## Token & Cost Semantics
+
+- **Additive token model**: the four buckets (`input`, `output`, `cacheRead`, `cacheWrite`) are independent and summed. Cached tokens are **not** subtracted from input (unlike Codex, where `input_tokens` include the cached portion). This matches the Claude cost model.
+- **`totalTokens` fallback**: when a message's `totalTokens` exceeds the sum of the known buckets, the surplus is folded into `output_tokens` (when output is 0). This matches upstream's `apply_total_token_fallback` and ensures reported token totals account for the full usage.
+- **Cost**: pi writes a per-message `cost.total` (USD). The default `auto` cost mode uses it directly; `calculate` mode recomputes from tokens via the shared pricing engine.
+- **No model prefix**: per the upstream omp PR, models are NOT prefixed (`[pi]`/`[omp]`). Both directories share the same `pi` source label and the same pricing lookup.
+
+### Metric mapping
+
+| pi `message.usage` field | Mapped to                     |
+| ------------------------ | ----------------------------- |
+| `input`                  | `input_tokens`                |
+| `output`                 | `output_tokens`               |
+| `cacheRead`              | `cache_read_input_tokens`     |
+| `cacheWrite`             | `cache_creation_input_tokens` |
+| `totalTokens`            | surplus fallback (see above)  |
+
+### Record filtering
+
+A JSONL line is accepted as a billable message when:
+
+- `type` is absent or `"message"` (event/tool lines are skipped)
+- `message.role === "assistant"` (user messages are skipped)
+- `message.usage` is present
+
+Zero-token messages and messages without a model are skipped (the latter cannot be priced without guessing).
+
+## Supported Models
+
+Any model named in a pi/omp session is priced via the shared pricing database (LiteLLM). Models absent from the pricing dataset are reported with `$0.00` in `calculate` mode.
+
+## Related
+
+- [Daily Reports](/guide/daily-reports.md)
+- [Monthly Reports](/guide/monthly-reports.md)
+- [Session Reports](/guide/session-reports.md)
+- [Cost Modes](/guide/cost-modes.md)
+- [Environment Variables](/guide/environment-variables.md)


### PR DESCRIPTION
## Summary

Adds a new `pi` source adapter that reads JSONL session files from [pi](https://github.com/anthropics/pi) and its fork [oh-my-pi (omp)](https://github.com/oh-my-pi/omp), aggregated alongside the existing 6 sources (claude/droid/zcode/codex/opencode/devin).

Ported from upstream ccusage (pi adapter default branch + PR [ccusage/ccusage#1338](https://github.com/ccusage/ccusage/pull/1338) for omp auto-detection).

## What it reads

- **JSONL sessions** under `~/.pi/agent/sessions/**/*.jsonl` AND `~/.omp/agent/sessions/**/*.jsonl`
- **Auto-detection**: when neither `PI_AGENT_DIR` nor a custom path is set, both directories are scanned (existing ones only), order `.pi` then `.omp`. Matches upstream PR #1338.
- **Dedup**: entries are collapsed by the loader's `createUniqueHash`, so a session present in both dirs is counted once.

## Token & cost semantics (verified against upstream Rust)

- **Additive** token model: `input`/`output`/`cacheRead`/`cacheWrite` are independent buckets, summed. NO cache subtraction from input \u2014 opposite of Codex. Matches upstream `pi/parser.rs`.
- **`totalTokens` fallback**: when `totalTokens > known sum`, surplus folds into `output_tokens` (when output is 0), else dropped (no cost impact). Matches upstream `apply_total_token_fallback`.
- **Cost**: `message.usage.cost.total` (USD) emitted as `costUSD`. Default `auto` mode uses it directly.
- **No model prefix** (`[pi]`/`[omp]`): both dirs share the `pi` source label and pricing lookup (matches PR #1338 \u2014 the `Default` scope upstream).
- Record acceptance: `type` absent or `"message"` + `role === "assistant"` + `usage` present.

## Changes

- **`_consts.ts`**: `SOURCE_ORDER` += `'pi'` (now 7 sources \u2192 127 auto-generated subsets); pi/omp path constants + `PI_SESSION_GLOB`.
- **`pi-adapter.ts`** (new, ~600 lines incl. tests): `getPiPaths(): string[]` (multi-dirs!) + `processPiSessions(dirs, options)` + valibot schemas + `applyTotalTokenFallback` + `extractProject` (with `path.normalize` for Windows glob paths).
- **`data-loader.ts`**: pi wired into all 3 loaders following the devin template, with multi-dir guards (`piPaths.length === 0 || (piPaths.length === 1 && piPaths[0] === '')`).
- **Docs**: new `docs/guide/pi.md`, README updated, `PI_AGENT_DIR` in environment-variables.md, Vitepress sidebar.

## Verification

- `pnpm --filter='better-ccusage' typecheck`: clean
- `pnpm --filter='better-ccusage' test`: **336 passed** (+17 new: 11 processPiSessions + 3 getPiPaths + 3 applyTotalTokenFallback)
- `pnpm --filter='better-ccusage' lint`: clean
- `pnpm --filter='better-ccusage' build`: clean
- **Backward compat e2e**: `monthly --compact` runs without regression on existing data.

## Code review (pre-push subagent)

The critical question \u2014 **does pi's `input` include `cacheRead` (double-counting)?** \u2014 verified against upstream Rust `pi/parser.rs`: **no**, additive model is correct (matches upstream). No hidden-session leak analog (pi has no DB). One review finding fixed before push: the `uniqueId` dedup key now includes `model` + `cacheRead:cacheCreation` (matching upstream `entry_id`) so same-instant messages with different buckets/models stay distinct.

Follow-up (not blocking): loader-level dedup integration test; `extra_total_tokens` surplus tracking (currently dropped, no cost impact).

## Refs
Upstream: https://github.com/ccusage/ccusage/pull/1338
Builds on #48 (sourceSchema) + #49 (devin adapter).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added usage tracking for pi and oh-my-pi sessions across reports and billing analysis.
  * Automatically detects pi/oh-my-pi session files, with support for custom directories through `PI_AGENT_DIR`.
  * Added “pi” as a selectable usage source.

* **Documentation**
  * Added a pi Source guide covering setup, file locations, token and cost handling, and reporting.
  * Updated CLI and environment-variable documentation with pi/oh-my-pi support details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->