### PR TITLE
fix(shims,cli): source subcommand, shim MODULE_NOT_FOUND, codex silent failure, CLI smoke tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,8 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Lint
-        run: pnpm run lint 2>&1 | sed 's/Error: Process completed.*/\x1b[0;31mError: Check failed - see above\x1b[0m/' || exit 1
+        run: |
+          pnpm run lint 2>&1 | sed 's/Error: Process completed.*/\x1b[0;31mError: Check failed - see above\x1b[0m/' || exit 1
 
       - name: Typecheck
         run: pnpm typecheck

--- a/apps/better-ccusage/README.md
+++ b/apps/better-ccusage/README.md
@@ -17,7 +17,7 @@
     <img src="https://cdn.jsdelivr.net/gh/cobra91/better-ccusage@main/docs/public/screenshot.png">
 </div>
 
-> Analyze your Claude Code, Droid, or ZCode token usage and costs from local JSONL/SQLite files with multi-provider support — incredibly fast and informative!
+> Analyze your Claude Code, Droid, ZCode, Codex, OpenCode, and Devin token usage and costs from local JSONL/SQLite files with multi-provider support — incredibly fast and informative!
 
 ## About better-ccusage
 
@@ -109,7 +109,22 @@ npx better-ccusage daily --instances --project myproject --json  # Combined usag
 # Compact mode for screenshots/sharing
 npx better-ccusage --compact  # Force compact table mode
 npx better-ccusage monthly --compact  # Compact monthly report
+
+# Focus on a single data source (Claude, Droid, ZCode, Codex, OpenCode, Devin)
+# By default every report aggregates all detected sources. Prefix the command
+# with a source name to see usage for that tool only:
+npx better-ccusage codex daily          # Codex-only daily report
+npx better-ccusage opencode blocks      # OpenCode-only billing blocks
+npx better-ccusage droid session        # Droid-only session report
+npx better-ccusage devin daily          # Devin-only daily report
+npx better-ccusage zcode monthly        # ZCode-only monthly report
+npx better-ccusage codex                # shorthand for "codex daily"
+# Equivalent explicit form (the positional form above is preferred):
+npx better-ccusage daily --source codex
 ```
+
+> 💡 **Tip**: Running `better-ccusage <source>` (e.g. `better-ccusage codex`) with no
+> report defaults to `daily`, the same shorthand upstream `ccusage` uses.
 
 ## Multi-Provider Support
 
@@ -203,6 +218,10 @@ better-ccusage extends the original ccusage functionality with automatic support
 | Show prompt usage for Coding     | ❌      | ✅             |
 | Droid usage                      | ❌      | ✅             |
 | ZCode usage                      | ❌      | ✅             |
+| Codex usage                      | ❌      | ✅             |
+| OpenCode usage                   | ❌      | ✅             |
+| Devin usage                      | ❌      | ✅             |
+| Per-source filtering             | ❌      | ✅             |
 
 ## Star History
 

--- a/apps/better-ccusage/config-schema.json
+++ b/apps/better-ccusage/config-schema.json
@@ -98,6 +98,19 @@
 							"description": "Force compact mode for narrow displays (better for screenshots)",
 							"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 							"default": false
+						},
+						"source": {
+							"type": "string",
+							"enum": [
+								"claude",
+								"droid",
+								"zcode",
+								"codex",
+								"opencode",
+								"devin"
+							],
+							"description": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`).",
+							"markdownDescription": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`)."
 						}
 					},
 					"additionalProperties": false,
@@ -196,6 +209,19 @@
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
+								},
+								"source": {
+									"type": "string",
+									"enum": [
+										"claude",
+										"droid",
+										"zcode",
+										"codex",
+										"opencode",
+										"devin"
+									],
+									"description": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`).",
+									"markdownDescription": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`)."
 								},
 								"instances": {
 									"type": "boolean",
@@ -305,6 +331,19 @@
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
+								},
+								"source": {
+									"type": "string",
+									"enum": [
+										"claude",
+										"droid",
+										"zcode",
+										"codex",
+										"opencode",
+										"devin"
+									],
+									"description": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`).",
+									"markdownDescription": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`)."
 								}
 							},
 							"additionalProperties": false
@@ -398,6 +437,19 @@
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
+								},
+								"source": {
+									"type": "string",
+									"enum": [
+										"claude",
+										"droid",
+										"zcode",
+										"codex",
+										"opencode",
+										"devin"
+									],
+									"description": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`).",
+									"markdownDescription": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`)."
 								},
 								"startOfWeek": {
 									"type": "string",
@@ -497,6 +549,19 @@
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
 								},
+								"source": {
+									"type": "string",
+									"enum": [
+										"claude",
+										"droid",
+										"zcode",
+										"codex",
+										"opencode",
+										"devin"
+									],
+									"description": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`).",
+									"markdownDescription": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`)."
+								},
 								"id": {
 									"type": "string",
 									"description": "Load usage data for a specific session ID",
@@ -594,6 +659,19 @@
 									"description": "Force compact mode for narrow displays (better for screenshots)",
 									"markdownDescription": "Force compact mode for narrow displays (better for screenshots)",
 									"default": false
+								},
+								"source": {
+									"type": "string",
+									"enum": [
+										"claude",
+										"droid",
+										"zcode",
+										"codex",
+										"opencode",
+										"devin"
+									],
+									"description": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`).",
+									"markdownDescription": "Filter to a single data source (claude, droid, zcode, codex, opencode, devin). Prefer the positional form: `better-ccusage <source> <report>` (e.g. `better-ccusage codex daily`)."
 								},
 								"active": {
 									"type": "boolean",

--- a/apps/better-ccusage/src/_consts.ts
+++ b/apps/better-ccusage/src/_consts.ts
@@ -55,6 +55,30 @@ const XDG_CONFIG_DIR = xdgConfig ?? path.join(USER_HOME_DIR, '.config');
 export const SOURCE_ORDER = ['claude', 'droid', 'zcode', 'codex', 'opencode', 'devin'] as const;
 
 /**
+ * Display labels for each source atom, matching the canonical capitalization
+ * used across the README, adapter logs, and docs (e.g. "OpenCode", "ZCode" —
+ * not "Opencode"/"Zcode"). Used for user-facing messages such as the
+ * "No <Source> usage data found." empty-result warning.
+ */
+const SOURCE_LABELS: Record<string, string> = {
+	claude: 'Claude',
+	droid: 'Droid',
+	zcode: 'ZCode',
+	codex: 'Codex',
+	opencode: 'OpenCode',
+	devin: 'Devin',
+};
+
+/**
+ * Return the display label for a source atom, defaulting to "Claude" when no
+ * source filter is set (the aggregate case). Unknown values pass through
+ * unchanged so a typo never produces an empty label.
+ */
+export function sourceLabel(source?: string): string {
+	return source != null ? (SOURCE_LABELS[source] ?? source) : 'Claude';
+}
+
+/**
  * All non-empty subsets of {@link SOURCE_ORDER}, joined by '/' in canonical
  * order. Generated at module load so the list stays in sync with
  * `SOURCE_ORDER` (2^n - 1 combinations for n sources).

--- a/apps/better-ccusage/src/_shared-args.ts
+++ b/apps/better-ccusage/src/_shared-args.ts
@@ -1,7 +1,7 @@
 import type { Args } from 'gunshi';
 import type { CostMode, SortOrder } from './_types.ts';
 import * as v from 'valibot';
-import { DEFAULT_LOCALE } from './_consts.ts';
+import { DEFAULT_LOCALE, SOURCE_ORDER } from './_consts.ts';
 import { CostModes, filterDateSchema, SortOrders } from './_types.ts';
 
 /**
@@ -100,6 +100,11 @@ export const sharedArgs = {
 		type: 'boolean',
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
+	},
+	source: {
+		type: 'enum',
+		description: `Filter to a single data source (${SOURCE_ORDER.join(', ')}). Prefer the positional form: \`better-ccusage <source> <report>\` (e.g. \`better-ccusage codex daily\`).`,
+		choices: SOURCE_ORDER as unknown as readonly [string, ...string[]],
 	},
 } as const satisfies Args;
 

--- a/apps/better-ccusage/src/codex-adapter.ts
+++ b/apps/better-ccusage/src/codex-adapter.ts
@@ -267,27 +267,32 @@ export function getCodexPath(): string {
  * logged at debug/warn level and skipped rather than thrown.
  *
  * @param codexPath - Absolute path to the Codex sessions directory
- * @param _options - Load options (currently unused, kept for parity with the
- *   other adapters so the loaders can call it uniformly)
+ * @param options - Load options. `options.source` gates the "directory not
+ *   found" warning so it only fires when the user explicitly asked for codex.
  * @returns Transformed usage entries (one per `token_count` event delta)
  */
 export async function processCodexSessions(
 	codexPath: string,
-	_options: LoadOptions = {},
+	options: LoadOptions = {},
 ): Promise<UsageData[]> {
 	if (codexPath === '') {
 		logger.debug('Codex sessions path is empty, skipping');
 		return [];
 	}
 
+	// When the user explicitly asked for codex (e.g. `better-ccusage codex daily`),
+	// a missing directory is the #1 reason for "no data", so warn loudly. When
+	// aggregating all sources (default), a machine that simply doesn't use Codex
+	// must stay quiet — otherwise every Claude-only user sees a spurious warn.
+	const optedIn = options.source === 'codex';
+	const dirMissingLog = optedIn ? logger.warn : logger.debug;
+
 	const dirStat = await Result.try({
 		try: async () => stat(codexPath),
 		catch: error => error,
 	})();
 	if (Result.isFailure(dirStat) || !dirStat.value.isDirectory()) {
-		// warn (not debug): a missing Codex directory is the most common reason
-		// Codex data is invisible in reports, and debug is hidden by default.
-		logger.warn(`Codex sessions directory not found or not a directory: ${codexPath}`);
+		dirMissingLog(`Codex sessions directory not found or not a directory: ${codexPath}`);
 		return [];
 	}
 
@@ -297,8 +302,9 @@ export async function processCodexSessions(
 	});
 
 	if (files.length === 0) {
-		// Directory exists but has no .jsonl session files — surface it so the
-		// user can tell an empty dir apart from a misconfigured CODEX_HOME.
+		// Directory exists but has no .jsonl session files. This only fires when
+		// the dir genuinely exists (so the user likely uses Codex) — safe to warn
+		// regardless of opt-in.
 		logger.warn(`Codex sessions directory exists but contains no .jsonl files: ${codexPath}`);
 		return [];
 	}

--- a/apps/better-ccusage/src/codex-adapter.ts
+++ b/apps/better-ccusage/src/codex-adapter.ts
@@ -285,7 +285,9 @@ export async function processCodexSessions(
 		catch: error => error,
 	})();
 	if (Result.isFailure(dirStat) || !dirStat.value.isDirectory()) {
-		logger.debug(`Codex sessions directory not found or not a directory: ${codexPath}`);
+		// warn (not debug): a missing Codex directory is the most common reason
+		// Codex data is invisible in reports, and debug is hidden by default.
+		logger.warn(`Codex sessions directory not found or not a directory: ${codexPath}`);
 		return [];
 	}
 
@@ -294,7 +296,18 @@ export async function processCodexSessions(
 		absolute: true,
 	});
 
+	if (files.length === 0) {
+		// Directory exists but has no .jsonl session files — surface it so the
+		// user can tell an empty dir apart from a misconfigured CODEX_HOME.
+		logger.warn(`Codex sessions directory exists but contains no .jsonl files: ${codexPath}`);
+		return [];
+	}
+
 	const results: UsageData[] = [];
+	// Aggregate diagnostics across all session files so we can emit ONE helpful
+	// message at the end instead of N per-file warnings (which would be noisy).
+	let tokenCountEvents = 0;
+	let droppedNoUsage = 0;
 
 	for (const file of files) {
 		const relativeSessionPath = path.relative(codexPath, file);
@@ -306,7 +319,7 @@ export async function processCodexSessions(
 			catch: error => error,
 		})();
 		if (Result.isFailure(fileContentResult)) {
-			logger.debug(`Failed to read Codex session file ${file}: ${String(fileContentResult.error)}`);
+			logger.warn(`Failed to read Codex session file ${file}: ${String(fileContentResult.error)}`);
 			continue;
 		}
 
@@ -357,6 +370,8 @@ export async function processCodexSessions(
 				continue;
 			}
 
+			tokenCountEvents += 1;
+
 			if (timestamp == null) {
 				continue;
 			}
@@ -375,6 +390,7 @@ export async function processCodexSessions(
 			}
 
 			if (raw == null) {
+				droppedNoUsage += 1;
 				continue;
 			}
 
@@ -435,7 +451,24 @@ export async function processCodexSessions(
 		}
 	}
 
-	logger.info(`Loaded ${results.length} Codex usage entries from ${codexPath}`);
+	logger.info(`Loaded ${results.length} Codex usage entries from ${codexPath} (${files.length} session file${files.length === 1 ? '' : 's'})`);
+
+	// The single most common cause of "Codex data is invisible": the user runs
+	// the Codex TUI interactively, and interactive sessions do not write
+	// per-turn token_count events to the rollout JSONL (only `codex exec` does).
+	// See https://github.com/openai/codex/issues/9660. Without this warning the
+	// adapter returns [] with no explanation.
+	if (results.length === 0 && tokenCountEvents > 0 && droppedNoUsage === tokenCountEvents) {
+		logger.warn(
+			`Codex sessions at ${codexPath} contained ${tokenCountEvents} token_count event(s) but none had usable usage data (last_token_usage/total_token_usage). This is expected for interactive Codex TUI sessions, which do not log per-turn token usage to disk — see https://github.com/openai/codex/issues/9660. Use \`codex exec\` (non-interactive) if you need usage logging.`,
+		);
+	}
+	else if (results.length === 0) {
+		logger.warn(
+			`No Codex usage entries were extracted from ${files.length} session file(s) at ${codexPath}. The files exist but contain no token_count events with non-zero deltas.`,
+		);
+	}
+
 	return results;
 }
 
@@ -618,6 +651,49 @@ if (import.meta.vitest != null) {
 
 			const results = await processCodexSessions(fixture.getPath('sessions'));
 			expect(results).toHaveLength(0);
+		});
+
+		it('warns when token_count events have no usable usage (interactive session shape)', async () => {
+			// Reproduces the "codex invisible in --breakdown" bug: an interactive
+			// Codex TUI session writes event_msg/token_count entries but with an
+			// empty info object (no last_token_usage / total_token_usage). The
+			// adapter must (a) return [] and (b) warn pointing at #9660 instead
+			// of failing silently. See https://github.com/openai/codex/issues/9660.
+			await using fixture = await createFixture({
+				sessions: {
+					'interactive.jsonl': [
+						JSON.stringify({
+							timestamp: '2025-09-18T10:00:00.000Z',
+							type: 'session_meta',
+							payload: { id: 'sess-1' },
+						}),
+						JSON.stringify({
+							timestamp: '2025-09-18T10:00:05.000Z',
+							type: 'event_msg',
+							payload: { type: 'token_count', info: {} },
+						}),
+						JSON.stringify({
+							timestamp: '2025-09-18T10:00:10.000Z',
+							type: 'event_msg',
+							payload: { type: 'agent_message', content: 'hi' },
+						}),
+					].join('\n'),
+				},
+			});
+
+			const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+			try {
+				const results = await processCodexSessions(fixture.getPath('sessions'));
+				expect(results).toHaveLength(0);
+				// Exactly one #9660 diagnostic should be emitted (not N per-event).
+				const diagnosticCalls = warnSpy.mock.calls.filter(args =>
+					String(args[0]).includes('openai/codex/issues/9660'),
+				);
+				expect(diagnosticCalls).toHaveLength(1);
+			}
+			finally {
+				warnSpy.mockRestore();
+			}
 		});
 	});
 

--- a/apps/better-ccusage/src/codex-adapter.ts
+++ b/apps/better-ccusage/src/codex-adapter.ts
@@ -376,11 +376,15 @@ export async function processCodexSessions(
 				continue;
 			}
 
-			tokenCountEvents += 1;
-
 			if (timestamp == null) {
 				continue;
 			}
+
+			// Count only events that reached the usage-extraction step, so the
+			// #9660 diagnostic condition (droppedNoUsage === tokenCountEvents)
+			// accurately reflects "every usable event lacked usage data" — a
+			// timestamp-missing event must not inflate the denominator.
+			tokenCountEvents += 1;
 
 			const info = tokenPayloadResult.output.info;
 			const lastUsage = normalizeRawUsage(info?.last_token_usage);

--- a/apps/better-ccusage/src/commands/blocks.ts
+++ b/apps/better-ccusage/src/commands/blocks.ts
@@ -185,7 +185,11 @@ export const blocksCommand = define({
 				log(JSON.stringify({ blocks: [] }));
 			}
 			else {
-				logger.warn('No Claude usage data found.');
+				const src = ctx.values.source;
+				const srcLabel = src != null
+					? `${src[0]!.toUpperCase()}${src.slice(1)}`
+					: 'Claude';
+				logger.warn(`No ${srcLabel} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/blocks.ts
+++ b/apps/better-ccusage/src/commands/blocks.ts
@@ -177,6 +177,7 @@ export const blocksCommand = define({
 			sessionDurationHours: ctx.values.sessionLength,
 			timezone: ctx.values.timezone,
 			locale: ctx.values.locale,
+			source: ctx.values.source,
 		});
 
 		if (blocks.length === 0) {

--- a/apps/better-ccusage/src/commands/blocks.ts
+++ b/apps/better-ccusage/src/commands/blocks.ts
@@ -5,7 +5,7 @@ import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
-import { BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_DEFAULT_TERMINAL_WIDTH, BLOCKS_WARNING_THRESHOLD, DEFAULT_RECENT_DAYS, DEFAULT_REFRESH_INTERVAL_SECONDS, MAX_REFRESH_INTERVAL_SECONDS, MIN_REFRESH_INTERVAL_SECONDS } from '../_consts.ts';
+import { BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_DEFAULT_TERMINAL_WIDTH, BLOCKS_WARNING_THRESHOLD, DEFAULT_RECENT_DAYS, DEFAULT_REFRESH_INTERVAL_SECONDS, MAX_REFRESH_INTERVAL_SECONDS, MIN_REFRESH_INTERVAL_SECONDS, sourceLabel } from '../_consts.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import {
 	calculateBurnRate,
@@ -185,11 +185,7 @@ export const blocksCommand = define({
 				log(JSON.stringify({ blocks: [] }));
 			}
 			else {
-				const src = ctx.values.source;
-				const srcLabel = src != null
-					? `${src[0]!.toUpperCase()}${src.slice(1)}`
-					: 'Claude';
-				logger.warn(`No ${srcLabel} usage data found.`);
+				logger.warn(`No ${sourceLabel(ctx.values.source)} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/daily.ts
+++ b/apps/better-ccusage/src/commands/daily.ts
@@ -79,7 +79,10 @@ export const dailyCommand = define({
 				log(JSON.stringify([]));
 			}
 			else {
-				logger.warn('No Claude usage data found.');
+				const srcLabel = mergedOptions.source != null
+					? `${mergedOptions.source[0]!.toUpperCase()}${mergedOptions.source.slice(1)}`
+					: 'Claude';
+				logger.warn(`No ${srcLabel} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/daily.ts
+++ b/apps/better-ccusage/src/commands/daily.ts
@@ -5,6 +5,7 @@ import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import pc from 'picocolors';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
+import { sourceLabel } from '../_consts.ts';
 import { groupByProject, groupDataByProject } from '../_daily-grouping.ts';
 import { formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
@@ -79,10 +80,7 @@ export const dailyCommand = define({
 				log(JSON.stringify([]));
 			}
 			else {
-				const srcLabel = mergedOptions.source != null
-					? `${mergedOptions.source[0]!.toUpperCase()}${mergedOptions.source.slice(1)}`
-					: 'Claude';
-				logger.warn(`No ${srcLabel} usage data found.`);
+				logger.warn(`No ${sourceLabel(mergedOptions.source)} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/index.test.ts
+++ b/apps/better-ccusage/src/commands/index.test.ts
@@ -1,0 +1,190 @@
+import type { Args } from 'gunshi';
+import process from 'node:process';
+import { SOURCE_ORDER } from '../_consts.ts';
+
+/**
+ * Smoke tests for the CLI dispatch layer (commands/index.ts).
+ *
+ * The original motivation: `better-ccusage codex` threw a raw
+ * `Command not found: codex` stack trace, and no test exercised the CLI entry
+ * point — so the regression shipped. These tests cover the argv rewrite that
+ * powers `better-ccusage <source> <report>` and the friendly unknown-command
+ * error, which are the two pieces of logic gunshi does not provide and that
+ * broke silently.
+ *
+ * We test `rewriteArgv` directly (a pure function) rather than driving the full
+ * `run()` + gunshi path, because the latter would require mocking the pricing
+ * fetcher, every adapter, and consola — all of which are already covered by
+ * their own unit tests. A few `run()` tests mock gunshi's `cli` to assert the
+ * rewritten argv reaches it.
+ */
+
+// vi.mock is hoisted before imports. We mock gunshi's `cli` so we can capture
+// the argv it receives without actually running a report (which would hit the
+// filesystem and pricing network). `vi` comes from vitest globals (see
+// vitest.config.ts `globals: true`).
+const cliMock = vi.fn<(args: string[], command: unknown, options?: { subCommands?: Map<string, unknown> }) => Promise<void>>();
+vi.mock('gunshi', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('gunshi')>();
+	return {
+		...actual,
+		cli: async (...args: Parameters<typeof actual.cli>) => cliMock(...args) as unknown as ReturnType<typeof actual.cli>,
+	};
+});
+
+// Import AFTER the mock is registered so commands/index.ts picks up the mock.
+const { run, rewriteArgv, subCommandUnion, UnknownCommandError } = await import('./index.ts');
+
+const reportNames = subCommandUnion.map(([n]) => n);
+
+describe('rewriteArgv', () => {
+	describe('source-as-subcommand syntax', () => {
+		for (const source of SOURCE_ORDER) {
+			it(`rewrites '<source> daily' to 'daily --source <source>' for ${source}`, () => {
+				const out = rewriteArgv([source, 'daily']);
+				expect(out).toEqual(['daily', '--source', source]);
+			});
+
+			it(`rewrites '<source> <report> --flag' preserving flags for ${source}`, () => {
+				const out = rewriteArgv([source, 'blocks', '--live', '--since', '20260101']);
+				expect(out).toEqual(['blocks', '--live', '--since', '20260101', '--source', source]);
+			});
+		}
+
+		it('defaults to daily when a source is given with no report', () => {
+			expect(rewriteArgv(['codex'])).toEqual(['daily', '--source', 'codex']);
+		});
+
+		it('defaults to daily when a source is followed by flags but no report', () => {
+			expect(rewriteArgv(['codex', '--json'])).toEqual(['daily', '--json', '--source', 'codex']);
+		});
+
+		it('treats a source followed by an unknown word as source + daily (not error)', () => {
+			// 'codex foo' → codex is a source, 'foo' is not a report → shorthand
+			// to 'codex daily' with 'foo' carried as a positional/rest.
+			const out = rewriteArgv(['codex', 'foo']);
+			expect(out).toEqual(['daily', 'foo', '--source', 'codex']);
+		});
+	});
+
+	describe('plain report syntax (unchanged)', () => {
+		for (const report of reportNames) {
+			it(`leaves '<report>' untouched for ${report}`, () => {
+				expect(rewriteArgv([report])).toEqual([report]);
+			});
+
+			it(`leaves '<report> --flags' untouched for ${report}`, () => {
+				expect(rewriteArgv([report, '--json', '--breakdown'])).toEqual([report, '--json', '--breakdown']);
+			});
+		}
+	});
+
+	describe('flags-first / empty argv', () => {
+		it('leaves a leading flag untouched', () => {
+			expect(rewriteArgv(['--version'])).toEqual(['--version']);
+		});
+
+		it('leaves empty argv untouched', () => {
+			expect(rewriteArgv([])).toEqual([]);
+		});
+	});
+
+	describe('unknown commands', () => {
+		it('throws UnknownCommandError for an unknown positional', () => {
+			try {
+				rewriteArgv(['foobar']);
+				throw new Error('expected rewriteArgv to throw');
+			}
+			catch (error) {
+				expect(error).toBeInstanceOf(UnknownCommandError);
+				expect((error as InstanceType<typeof UnknownCommandError>).unknown).toBe('foobar');
+				expect((error as Error).message).toMatch(/Unknown command or source: 'foobar'/);
+				expect((error as Error).message).toMatch(/Commands: daily, monthly/);
+				expect((error as Error).message).toMatch(/Sources:\s+claude, droid, zcode, codex, opencode, devin/);
+			}
+		});
+
+		it('does NOT throw for an unknown positional when it could be a value', () => {
+			// 'daily foobar' → daily is a report, foobar is a positional/rest,
+			// not a subcommand selector → left untouched.
+			expect(rewriteArgv(['daily', 'foobar'])).toEqual(['daily', 'foobar']);
+		});
+	});
+});
+
+describe('run (CLI dispatch)', () => {
+	afterEach(() => {
+		cliMock.mockReset();
+		vi.restoreAllMocks();
+	});
+
+	it('rewrites "<source> <report>" before dispatching to gunshi', async () => {
+		const originalArgv = process.argv;
+		process.argv = ['node', 'better-ccusage', 'codex', 'daily', '--breakdown'];
+		try {
+			await run();
+			expect(cliMock).toHaveBeenCalledTimes(1);
+			const dispatchedArgs = cliMock.mock.calls[0]![0];
+			expect(dispatchedArgs).toEqual(['daily', '--breakdown', '--source', 'codex']);
+		}
+		finally {
+			process.argv = originalArgv;
+		}
+	});
+
+	it('strips a duplicated binary name (npx edge case) before rewriting', async () => {
+		const originalArgv = process.argv;
+		process.argv = ['node', 'better-ccusage', 'better-ccusage', 'codex', 'monthly'];
+		try {
+			await run();
+			expect(cliMock).toHaveBeenCalledTimes(1);
+			expect(cliMock.mock.calls[0]![0]).toEqual(['monthly', '--source', 'codex']);
+		}
+		finally {
+			process.argv = originalArgv;
+		}
+	});
+
+	it('passes a plain report through to gunshi unmodified', async () => {
+		const originalArgv = process.argv;
+		process.argv = ['node', 'better-ccusage', 'daily', '--json'];
+		try {
+			await run();
+			expect(cliMock).toHaveBeenCalledTimes(1);
+			expect(cliMock.mock.calls[0]![0]).toEqual(['daily', '--json']);
+		}
+		finally {
+			process.argv = originalArgv;
+		}
+	});
+
+	it('exits non-zero with a friendly message (no stack trace) for an unknown command', async () => {
+		const originalArgv = process.argv;
+		const { logger } = await import('../logger.ts');
+		const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+			throw new Error(`process.exit(${code ?? 0})`);
+		});
+		process.argv = ['node', 'better-ccusage', 'totallyBogus'];
+		try {
+			await expect(run()).rejects.toThrow(/process\.exit\(1\)/);
+			// gunshi must NOT have been reached (we failed before dispatch).
+			expect(cliMock).not.toHaveBeenCalled();
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			// The friendly message is logged via logger.error.
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+			const logged = String(errorSpy.mock.calls[0]![0]);
+			expect(logged).toMatch(/Unknown command or source: 'totallyBogus'/);
+			expect(logged).toMatch(/Commands: daily, monthly/);
+			expect(logged).toMatch(/Sources:\s+claude, droid, zcode, codex, opencode, devin/);
+			// No raw stack trace leaks to the user-facing message.
+			expect(logged).not.toMatch(/at (async )?run/);
+		}
+		finally {
+			process.argv = originalArgv;
+		}
+	});
+});
+
+// Silence the unused-import lint for Args (kept for type discoverability).
+export type _Args = Args;

--- a/apps/better-ccusage/src/commands/index.test.ts
+++ b/apps/better-ccusage/src/commands/index.test.ts
@@ -1,4 +1,3 @@
-import type { Args } from 'gunshi';
 import process from 'node:process';
 import { SOURCE_ORDER } from '../_consts.ts';
 
@@ -185,6 +184,3 @@ describe('run (CLI dispatch)', () => {
 		}
 	});
 });
-
-// Silence the unused-import lint for Args (kept for type discoverability).
-export type _Args = Args;

--- a/apps/better-ccusage/src/commands/index.ts
+++ b/apps/better-ccusage/src/commands/index.ts
@@ -57,20 +57,37 @@ for (const [name, command] of subCommandUnion) {
 const mainCommand = dailyCommand;
 
 /**
- * Print a friendly "unknown command" message and exit non-zero.
+ * Error thrown when the first positional argv token is neither a registered
+ * report subcommand nor a known data source. {@link run} catches it, prints
+ * a friendly message (no stack trace), and exits non-zero. Kept as a typed
+ * error class so tests can distinguish it from gunshi's raw
+ * `Command not found:` throw.
+ */
+export class UnknownCommandError extends Error {
+	readonly unknown: string;
+
+	constructor(unknown: string) {
+		super(
+			`Unknown command or source: '${unknown}'\n`
+			+ `\nCommands: ${[...reportNames].join(', ')}`
+			+ `\nSources:  ${[...sourceNames].join(', ')} (use as: ${name} <source> <command>, e.g. ${name} codex daily)`,
+		);
+		this.name = 'UnknownCommandError';
+		this.unknown = unknown;
+	}
+}
+
+/**
+ * Build (and throw) the friendly "unknown command" error.
  *
  * gunshi 0.26 throws a raw `Command not found: <name>` with a stack trace when
  * the first positional is neither a registered subcommand nor omitted. We
  * intercept that here so users get a helpful list of valid commands and
- * sources instead of a stack trace.
+ * sources instead of a stack trace. Throwing (rather than calling process.exit
+ * directly) makes the path unit-testable.
  */
 function failUnknownCommand(unknown: string): never {
-	logger.error(
-		`Unknown command or source: '${unknown}'\n`
-		+ `\nCommands: ${[...reportNames].join(', ')}`
-		+ `\nSources:  ${[...sourceNames].join(', ')} (use as: ${name} <source> <command>, e.g. ${name} codex daily)`,
-	);
-	process.exit(1);
+	throw new UnknownCommandError(unknown);
 }
 
 /**
@@ -83,9 +100,13 @@ function failUnknownCommand(unknown: string): never {
  * Returns the (possibly rewritten) argv. When the first token is a source name
  * but the second is not a report (e.g. `better-ccusage codex` alone), the
  * function injects the default `daily` report so `better-ccusage codex` is a
- * shorthand for `better-ccusage codex daily`.
+ * shorthand for `better-ccusage codex daily`. Throws an {@link UnknownCommandError}
+ * for a first positional that is neither a report nor a source.
+ *
+ * Exported for unit testing (the CLI dispatch itself is hard to exercise
+ * without mocking the pricing fetcher and every adapter).
  */
-function rewriteArgv(args: string[]): string[] {
+export function rewriteArgv(args: string[]): string[] {
 	const first = args[0];
 	if (first == null || first.startsWith('-')) {
 		return args;
@@ -119,9 +140,12 @@ export async function run(): Promise<void> {
 		args = args.slice(1);
 	}
 
-	args = rewriteArgv(args);
-
 	try {
+		// rewriteArgv may throw UnknownCommandError for an unknown first
+		// positional; keep it inside the try so the catch turns it into the
+		// friendly logger.error + non-zero exit instead of a raw throw.
+		args = rewriteArgv(args);
+
 		await cli(args, mainCommand, {
 			name,
 			version,
@@ -131,14 +155,24 @@ export async function run(): Promise<void> {
 		});
 	}
 	catch (error) {
-		// Safety net: gunshi throws a raw `Command not found: <name>` (with a
-		// stack trace) for an unknown first positional. rewriteArgv should
-		// already have handled it, but guard against any other path that reaches
-		// here so users never see a bare stack trace.
+		// Friendly handling for unknown commands: either our UnknownCommandError
+		// (thrown by rewriteArgv, re-thrown here if it escaped) or gunshi's raw
+		// `Command not found: <name>` safety net. In both cases, print the
+		// helpful message and exit non-zero instead of showing a stack trace.
+		if (error instanceof UnknownCommandError) {
+			logger.error(error.message);
+			process.exit(1);
+		}
 		const message = error instanceof Error ? error.message : String(error);
 		if (message.startsWith('Command not found:')) {
 			const unknown = message.slice('Command not found:'.length).trim();
-			failUnknownCommand(unknown);
+			const display = unknown !== '' ? unknown : '<empty>';
+			logger.error(
+				`Unknown command or source: '${display}'\n`
+				+ `\nCommands: ${[...reportNames].join(', ')}`
+				+ `\nSources:  ${[...sourceNames].join(', ')} (use as: ${name} <source> <command>, e.g. ${name} codex daily)`,
+			);
+			process.exit(1);
 		}
 		throw error;
 	}

--- a/apps/better-ccusage/src/commands/index.ts
+++ b/apps/better-ccusage/src/commands/index.ts
@@ -1,6 +1,8 @@
 import process from 'node:process';
 import { cli } from 'gunshi';
 import packageJson from '../../package.json' with { type: 'json' };
+import { SOURCE_ORDER } from '../_consts.ts';
+import { logger } from '../logger.ts';
 import { blocksCommand } from './blocks.ts';
 import { dailyCommand } from './daily.ts';
 import { monthlyCommand } from './monthly.ts';
@@ -31,6 +33,17 @@ export const subCommandUnion = [
 export type CommandName = typeof subCommandUnion[number][0];
 
 /**
+ * Set of valid report subcommand names, for fast membership checks.
+ */
+const reportNames = new Set<string>(subCommandUnion.map(([n]) => n));
+
+/**
+ * Set of valid data-source names (claude, droid, zcode, codex, opencode, devin),
+ * for the `better-ccusage <source> <report>` positional syntax.
+ */
+const sourceNames = new Set<string>(SOURCE_ORDER);
+
+/**
  * Map of available CLI subcommands
  */
 const subCommands = new Map();
@@ -44,6 +57,57 @@ for (const [name, command] of subCommandUnion) {
 const mainCommand = dailyCommand;
 
 /**
+ * Print a friendly "unknown command" message and exit non-zero.
+ *
+ * gunshi 0.26 throws a raw `Command not found: <name>` with a stack trace when
+ * the first positional is neither a registered subcommand nor omitted. We
+ * intercept that here so users get a helpful list of valid commands and
+ * sources instead of a stack trace.
+ */
+function failUnknownCommand(unknown: string): never {
+	logger.error(
+		`Unknown command or source: '${unknown}'\n`
+		+ `\nCommands: ${[...reportNames].join(', ')}`
+		+ `\nSources:  ${[...sourceNames].join(', ')} (use as: ${name} <source> <command>, e.g. ${name} codex daily)`,
+	);
+	process.exit(1);
+}
+
+/**
+ * Rewrite the argv for the positional `<source> <report>` syntax into the
+ * canonical `<report> --source <source>` form, so gunshi dispatches to the
+ * report command with the source filter plumbed through.
+ *
+ * Example: `['codex', 'daily', '--breakdown']` → `['daily', '--breakdown', '--source', 'codex']`.
+ *
+ * Returns the (possibly rewritten) argv. When the first token is a source name
+ * but the second is not a report (e.g. `better-ccusage codex` alone), the
+ * function injects the default `daily` report so `better-ccusage codex` is a
+ * shorthand for `better-ccusage codex daily`.
+ */
+function rewriteArgv(args: string[]): string[] {
+	const first = args[0];
+	if (first == null || first.startsWith('-')) {
+		return args;
+	}
+
+	// `<source> <report> [...flags]` → `<report> [...flags] --source <source>`
+	if (sourceNames.has(first)) {
+		const [, second, ...rest] = args;
+		const report = second != null && reportNames.has(second) ? second : 'daily';
+		const flags = second != null && reportNames.has(second) ? rest : args.slice(1);
+		return [report, ...flags, '--source', first];
+	}
+
+	// Unknown positional that is not a report and not a source → friendly error.
+	if (!reportNames.has(first)) {
+		failUnknownCommand(first);
+	}
+
+	return args;
+}
+
+/**
  * Entry point for the CLI. Parses process arguments and delegates to Gunshi's
  * CLI runner with the configured subcommands.
  */
@@ -55,11 +119,27 @@ export async function run(): Promise<void> {
 		args = args.slice(1);
 	}
 
-	await cli(args, mainCommand, {
-		name,
-		version,
-		description,
-		subCommands,
-		renderHeader: null,
-	});
+	args = rewriteArgv(args);
+
+	try {
+		await cli(args, mainCommand, {
+			name,
+			version,
+			description,
+			subCommands,
+			renderHeader: null,
+		});
+	}
+	catch (error) {
+		// Safety net: gunshi throws a raw `Command not found: <name>` (with a
+		// stack trace) for an unknown first positional. rewriteArgv should
+		// already have handled it, but guard against any other path that reaches
+		// here so users never see a bare stack trace.
+		const message = error instanceof Error ? error.message : String(error);
+		if (message.startsWith('Command not found:')) {
+			const unknown = message.slice('Command not found:'.length).trim();
+			failUnknownCommand(unknown);
+		}
+		throw error;
+	}
 }

--- a/apps/better-ccusage/src/commands/monthly.ts
+++ b/apps/better-ccusage/src/commands/monthly.ts
@@ -4,7 +4,7 @@ import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUs
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
-import { DEFAULT_LOCALE } from '../_consts.ts';
+import { DEFAULT_LOCALE, sourceLabel } from '../_consts.ts';
 import { formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
@@ -50,10 +50,7 @@ export const monthlyCommand = define({
 				log(JSON.stringify(emptyOutput, null, 2));
 			}
 			else {
-				const srcLabel = mergedOptions.source != null
-					? `${mergedOptions.source[0]!.toUpperCase()}${mergedOptions.source.slice(1)}`
-					: 'Claude';
-				logger.warn(`No ${srcLabel} usage data found.`);
+				logger.warn(`No ${sourceLabel(mergedOptions.source)} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/monthly.ts
+++ b/apps/better-ccusage/src/commands/monthly.ts
@@ -50,7 +50,10 @@ export const monthlyCommand = define({
 				log(JSON.stringify(emptyOutput, null, 2));
 			}
 			else {
-				logger.warn('No Claude usage data found.');
+				const srcLabel = mergedOptions.source != null
+					? `${mergedOptions.source[0]!.toUpperCase()}${mergedOptions.source.slice(1)}`
+					: 'Claude';
+				logger.warn(`No ${srcLabel} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/session.ts
+++ b/apps/better-ccusage/src/commands/session.ts
@@ -73,7 +73,10 @@ export const sessionCommand = define({
 				log(JSON.stringify([]));
 			}
 			else {
-				logger.warn('No Claude usage data found.');
+				const srcLabel = mergedOptions.source != null
+					? `${mergedOptions.source[0]!.toUpperCase()}${mergedOptions.source.slice(1)}`
+					: 'Claude';
+				logger.warn(`No ${srcLabel} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/session.ts
+++ b/apps/better-ccusage/src/commands/session.ts
@@ -4,7 +4,7 @@ import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUs
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
-import { DEFAULT_LOCALE } from '../_consts.ts';
+import { DEFAULT_LOCALE, sourceLabel } from '../_consts.ts';
 import { formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedCommandConfig } from '../_shared-args.ts';
@@ -73,10 +73,7 @@ export const sessionCommand = define({
 				log(JSON.stringify([]));
 			}
 			else {
-				const srcLabel = mergedOptions.source != null
-					? `${mergedOptions.source[0]!.toUpperCase()}${mergedOptions.source.slice(1)}`
-					: 'Claude';
-				logger.warn(`No ${srcLabel} usage data found.`);
+				logger.warn(`No ${sourceLabel(mergedOptions.source)} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/session.ts
+++ b/apps/better-ccusage/src/commands/session.ts
@@ -65,6 +65,7 @@ export const sessionCommand = define({
 			mode: ctx.values.mode,
 			timezone: ctx.values.timezone,
 			locale: ctx.values.locale,
+			source: ctx.values.source,
 		});
 
 		if (sessionData.length === 0) {

--- a/apps/better-ccusage/src/commands/weekly.ts
+++ b/apps/better-ccusage/src/commands/weekly.ts
@@ -60,7 +60,10 @@ export const weeklyCommand = define({
 				log(JSON.stringify(emptyOutput, null, 2));
 			}
 			else {
-				logger.warn('No Claude usage data found.');
+				const srcLabel = mergedOptions.source != null
+					? `${mergedOptions.source[0]!.toUpperCase()}${mergedOptions.source.slice(1)}`
+					: 'Claude';
+				logger.warn(`No ${srcLabel} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/commands/weekly.ts
+++ b/apps/better-ccusage/src/commands/weekly.ts
@@ -4,7 +4,7 @@ import { addEmptySeparatorRow, createUsageReportTable, formatTotalsRow, formatUs
 import { Result } from '@praha/byethrow';
 import { define } from 'gunshi';
 import { loadConfig, mergeConfigWithArgs } from '../_config-loader-tokens.ts';
-import { WEEK_DAYS } from '../_consts.ts';
+import { sourceLabel, WEEK_DAYS } from '../_consts.ts';
 import { formatDateCompact } from '../_date-utils.ts';
 import { processWithJq } from '../_jq-processor.ts';
 import { sharedArgs } from '../_shared-args.ts';
@@ -60,10 +60,7 @@ export const weeklyCommand = define({
 				log(JSON.stringify(emptyOutput, null, 2));
 			}
 			else {
-				const srcLabel = mergedOptions.source != null
-					? `${mergedOptions.source[0]!.toUpperCase()}${mergedOptions.source.slice(1)}`
-					: 'Claude';
-				logger.warn(`No ${srcLabel} usage data found.`);
+				logger.warn(`No ${sourceLabel(mergedOptions.source)} usage data found.`);
 			}
 			process.exit(0);
 		}

--- a/apps/better-ccusage/src/data-loader.ts
+++ b/apps/better-ccusage/src/data-loader.ts
@@ -773,6 +773,18 @@ export type LoadOptions = {
 	startOfWeek?: WeekDay; // Start of week for weekly aggregation
 	timezone?: string; // Timezone for date grouping (e.g., 'UTC', 'America/New_York'). Defaults to system timezone
 	locale?: string; // Locale for date/time formatting (e.g., 'en-US', 'ja-JP'). Defaults to 'en-US'
+	/**
+	 * Restrict loading to a single data source atom ('claude' | 'droid' |
+	 * 'zcode' | 'codex' | 'opencode' | 'devin'). When unset, all sources are
+	 * loaded and aggregated (the default behavior). Set by the
+	 * `better-ccusage <source> <report>` subcommand syntax via the argv rewrite
+	 * in commands/index.ts; also accepted as the internal `--source` flag.
+	 *
+	 * Typed as `string` (not a literal union) because gunshi widens enum args
+	 * to `string`; the CLI `choices` constraint enforces valid values at the
+	 * boundary. Any non-matching string simply matches no adapter, yielding [].
+	 */
+	source?: string;
 } & DateFilter;
 
 /**
@@ -788,92 +800,109 @@ export type LoadOptions = {
 export async function loadDailyUsageData(
 	options?: LoadOptions,
 ): Promise<DailyUsage[]> {
-	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const sourceFilter = options?.source;
+
+	// Get all Claude paths or use the specific one from options.
+	// Skip Claude entirely when filtering to a different source: getClaudePaths()
+	// throws when no Claude data dir exists, which would break
+	// `better-ccusage codex daily` on a machine with no Claude data.
+	const claudePaths = sourceFilter != null && sourceFilter !== 'claude'
+		? []
+		: toArray(options?.claudePath ?? getClaudePaths());
 
 	// Collect files from all paths in parallel
 	const allFiles = await globUsageFiles(claudePaths);
 	const fileList = allFiles.map(f => f.file);
 
 	// Also load droid sessions if available
-	const droidPath = getDroidPath();
-	logger.debug(`Droid path: ${droidPath}`);
 	let droidEntries: UsageData[] = [];
-	if (droidPath === '') {
-		logger.debug('Droid path is null or undefined');
-	}
-	else {
-		try {
-			logger.debug(`Attempting to load droid sessions from ${droidPath}`);
-			droidEntries = await processDroidSessions(droidPath, options);
-			logger.info(`Loaded ${droidEntries.length} droid sessions from ${droidPath}`);
+	if (sourceFilter == null || sourceFilter === 'droid') {
+		const droidPath = getDroidPath();
+		logger.debug(`Droid path: ${droidPath}`);
+		if (droidPath === '') {
+			logger.debug('Droid path is null or undefined');
 		}
-		catch (error) {
-			logger.warn(`Failed to load droid sessions: ${String(error)}`);
+		else {
+			try {
+				logger.debug(`Attempting to load droid sessions from ${droidPath}`);
+				droidEntries = await processDroidSessions(droidPath, options);
+				logger.info(`Loaded ${droidEntries.length} droid sessions from ${droidPath}`);
+			}
+			catch (error) {
+				logger.warn(`Failed to load droid sessions: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load zcode usage from its SQLite database if available
-	const zcodeDbPath = getZcodeDbPath();
-	logger.debug(`ZCode database path: ${zcodeDbPath}`);
 	let zcodeEntries: UsageData[] = [];
-	if (zcodeDbPath === '') {
-		logger.debug('ZCode database path is empty');
-	}
-	else {
-		try {
-			zcodeEntries = await processZcodeSessions(zcodeDbPath, options);
+	if (sourceFilter == null || sourceFilter === 'zcode') {
+		const zcodeDbPath = getZcodeDbPath();
+		logger.debug(`ZCode database path: ${zcodeDbPath}`);
+		if (zcodeDbPath === '') {
+			logger.debug('ZCode database path is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load zcode sessions: ${String(error)}`);
+		else {
+			try {
+				zcodeEntries = await processZcodeSessions(zcodeDbPath, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load zcode sessions: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load Codex usage from its session JSONL logs if available
-	const codexPath = getCodexPath();
-	logger.debug(`Codex sessions path: ${codexPath}`);
 	let codexEntries: UsageData[] = [];
-	if (codexPath === '') {
-		logger.debug('Codex sessions path is empty');
-	}
-	else {
-		try {
-			codexEntries = await processCodexSessions(codexPath, options);
+	if (sourceFilter == null || sourceFilter === 'codex') {
+		const codexPath = getCodexPath();
+		logger.debug(`Codex sessions path: ${codexPath}`);
+		if (codexPath === '') {
+			logger.debug('Codex sessions path is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load codex sessions: ${String(error)}`);
+		else {
+			try {
+				codexEntries = await processCodexSessions(codexPath, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load codex sessions: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load OpenCode usage from its SQLite database if available
-	const opencodeDbPath = getOpenCodeDbPath();
-	logger.debug(`OpenCode database path: ${opencodeDbPath}`);
 	let opencodeEntries: UsageData[] = [];
-	if (opencodeDbPath === '') {
-		logger.debug('OpenCode database path is empty');
-	}
-	else {
-		try {
-			opencodeEntries = await processOpenCodeSessions(opencodeDbPath, options);
+	if (sourceFilter == null || sourceFilter === 'opencode') {
+		const opencodeDbPath = getOpenCodeDbPath();
+		logger.debug(`OpenCode database path: ${opencodeDbPath}`);
+		if (opencodeDbPath === '') {
+			logger.debug('OpenCode database path is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load opencode sessions: ${String(error)}`);
+		else {
+			try {
+				opencodeEntries = await processOpenCodeSessions(opencodeDbPath, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load opencode sessions: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load Devin usage from its ATIF transcripts if available
-	const devinPath = getDevinPath();
-	logger.debug(`Devin data directory: ${devinPath}`);
 	let devinEntries: UsageData[] = [];
-	if (devinPath === '') {
-		logger.debug('Devin data directory is empty');
-	}
-	else {
-		try {
-			devinEntries = await processDevinSessions(devinPath, options);
+	if (sourceFilter == null || sourceFilter === 'devin') {
+		const devinPath = getDevinPath();
+		logger.debug(`Devin data directory: ${devinPath}`);
+		if (devinPath === '') {
+			logger.debug('Devin data directory is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load devin sessions: ${String(error)}`);
+		else {
+			try {
+				devinEntries = await processDevinSessions(devinPath, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load devin sessions: ${String(error)}`);
+			}
 		}
 	}
 
@@ -1160,91 +1189,107 @@ export async function loadDailyUsageData(
 export async function loadSessionData(
 	options?: LoadOptions,
 ): Promise<SessionUsage[]> {
-	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const sourceFilter = options?.source;
+
+	// Get all Claude paths or use the specific one from options.
+	// Skip Claude entirely when filtering to a different source (see
+	// loadDailyUsageData for the getClaudePaths() throw rationale).
+	const claudePaths = sourceFilter != null && sourceFilter !== 'claude'
+		? []
+		: toArray(options?.claudePath ?? getClaudePaths());
 
 	// Collect files from all paths with their base directories in parallel
 	const filesWithBase = await globUsageFiles(claudePaths);
 
 	// Also load droid sessions if available
-	const droidPath = getDroidPath();
-	logger.debug(`Droid path: ${droidPath}`);
 	let droidEntries: UsageData[] = [];
-	if (droidPath === '') {
-		logger.debug('Droid path is null or undefined');
-	}
-	else {
-		try {
-			logger.debug(`Attempting to load droid sessions from ${droidPath}`);
-			droidEntries = await processDroidSessions(droidPath, options);
-			logger.info(`Loaded ${droidEntries.length} droid sessions from ${droidPath}`);
+	if (sourceFilter == null || sourceFilter === 'droid') {
+		const droidPath = getDroidPath();
+		logger.debug(`Droid path: ${droidPath}`);
+		if (droidPath === '') {
+			logger.debug('Droid path is null or undefined');
 		}
-		catch (error) {
-			logger.warn(`Failed to load droid sessions: ${String(error)}`);
+		else {
+			try {
+				logger.debug(`Attempting to load droid sessions from ${droidPath}`);
+				droidEntries = await processDroidSessions(droidPath, options);
+				logger.info(`Loaded ${droidEntries.length} droid sessions from ${droidPath}`);
+			}
+			catch (error) {
+				logger.warn(`Failed to load droid sessions: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load zcode usage from its SQLite database if available
-	const zcodeDbPath = getZcodeDbPath();
-	logger.debug(`ZCode database path: ${zcodeDbPath}`);
 	let zcodeEntries: UsageData[] = [];
-	if (zcodeDbPath === '') {
-		logger.debug('ZCode database path is empty');
-	}
-	else {
-		try {
-			zcodeEntries = await processZcodeSessions(zcodeDbPath, options);
+	if (sourceFilter == null || sourceFilter === 'zcode') {
+		const zcodeDbPath = getZcodeDbPath();
+		logger.debug(`ZCode database path: ${zcodeDbPath}`);
+		if (zcodeDbPath === '') {
+			logger.debug('ZCode database path is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load zcode sessions: ${String(error)}`);
+		else {
+			try {
+				zcodeEntries = await processZcodeSessions(zcodeDbPath, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load zcode sessions: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load Codex usage from its session JSONL logs if available
-	const codexPath = getCodexPath();
-	logger.debug(`Codex sessions path: ${codexPath}`);
 	let codexEntries: UsageData[] = [];
-	if (codexPath === '') {
-		logger.debug('Codex sessions path is empty');
-	}
-	else {
-		try {
-			codexEntries = await processCodexSessions(codexPath, options);
+	if (sourceFilter == null || sourceFilter === 'codex') {
+		const codexPath = getCodexPath();
+		logger.debug(`Codex sessions path: ${codexPath}`);
+		if (codexPath === '') {
+			logger.debug('Codex sessions path is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load codex sessions: ${String(error)}`);
+		else {
+			try {
+				codexEntries = await processCodexSessions(codexPath, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load codex sessions: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load OpenCode usage from its SQLite database if available
-	const opencodeDbPath = getOpenCodeDbPath();
-	logger.debug(`OpenCode database path: ${opencodeDbPath}`);
 	let opencodeEntries: UsageData[] = [];
-	if (opencodeDbPath === '') {
-		logger.debug('OpenCode database path is empty');
-	}
-	else {
-		try {
-			opencodeEntries = await processOpenCodeSessions(opencodeDbPath, options);
+	if (sourceFilter == null || sourceFilter === 'opencode') {
+		const opencodeDbPath = getOpenCodeDbPath();
+		logger.debug(`OpenCode database path: ${opencodeDbPath}`);
+		if (opencodeDbPath === '') {
+			logger.debug('OpenCode database path is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load opencode sessions: ${String(error)}`);
+		else {
+			try {
+				opencodeEntries = await processOpenCodeSessions(opencodeDbPath, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load opencode sessions: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load Devin usage from its ATIF transcripts if available
-	const devinPath = getDevinPath();
-	logger.debug(`Devin data directory: ${devinPath}`);
 	let devinEntries: UsageData[] = [];
-	if (devinPath === '') {
-		logger.debug('Devin data directory is empty');
-	}
-	else {
-		try {
-			devinEntries = await processDevinSessions(devinPath, options);
+	if (sourceFilter == null || sourceFilter === 'devin') {
+		const devinPath = getDevinPath();
+		logger.debug(`Devin data directory: ${devinPath}`);
+		if (devinPath === '') {
+			logger.debug('Devin data directory is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load devin sessions: ${String(error)}`);
+		else {
+			try {
+				devinEntries = await processDevinSessions(devinPath, options);
+			}
+			catch (error) {
+				logger.warn(`Failed to load devin sessions: ${String(error)}`);
+			}
 		}
 	}
 
@@ -1816,8 +1861,14 @@ export async function calculateContextTokens(transcriptPath: string, modelId?: s
 export async function loadSessionBlockData(
 	options?: LoadOptions,
 ): Promise<SessionBlock[]> {
-	// Get all Claude paths or use the specific one from options
-	const claudePaths = toArray(options?.claudePath ?? getClaudePaths());
+	const sourceFilter = options?.source;
+
+	// Get all Claude paths or use the specific one from options.
+	// Skip Claude entirely when filtering to a different source (see
+	// loadDailyUsageData for the getClaudePaths() throw rationale).
+	const claudePaths = sourceFilter != null && sourceFilter !== 'claude'
+		? []
+		: toArray(options?.claudePath ?? getClaudePaths());
 
 	// Collect files from all paths
 	const allFiles: string[] = [];
@@ -1924,113 +1975,119 @@ export async function loadSessionBlockData(
 	}
 
 	// Also load droid sessions if available
-	const droidPath = getDroidPath();
-	logger.debug(`Droid path for blocks: ${droidPath}`);
 	let droidEntries: LoadedUsageEntry[] = [];
-	if (droidPath === '') {
-		logger.debug('Droid path for blocks is null or undefined');
-	}
-	else {
-		try {
-			logger.debug(`Attempting to load droid sessions for blocks from ${droidPath}`);
-			const rawDroidEntries = await processDroidSessions(droidPath, options);
-			// Convert droid entries to LoadedUsageEntry format with Date timestamps
-			droidEntries = await Promise.all(rawDroidEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
-				timestamp: new Date(entry.timestamp),
-				usage: {
-					inputTokens: entry.message.usage.input_tokens,
-					outputTokens: entry.message.usage.output_tokens,
-					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
-					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
-				},
-				// Droid entries do not carry a pre-computed costUSD (the adapter
-				// delegates pricing to the shared engine), so we must compute it
-				// here with the same fetcher/mode as the Claude path. Without
-				// this, every droid session block would report $0.
-				costUSD: fetcher == null
-					? entry.costUSD ?? 0
-					: await calculateCostForEntry(entry, mode, fetcher),
-				model: entry.message.model ?? 'unknown',
-				version: entry.version ?? undefined,
-				usageLimitResetTime: undefined,
-				source: entry.source ?? 'droid',
-			})));
-			logger.info(`Loaded ${droidEntries.length} droid entries for blocks from ${droidPath}`);
+	if (sourceFilter == null || sourceFilter === 'droid') {
+		const droidPath = getDroidPath();
+		logger.debug(`Droid path for blocks: ${droidPath}`);
+		if (droidPath === '') {
+			logger.debug('Droid path for blocks is null or undefined');
 		}
-		catch (error) {
-			logger.warn(`Failed to load droid sessions for blocks: ${String(error)}`);
+		else {
+			try {
+				logger.debug(`Attempting to load droid sessions for blocks from ${droidPath}`);
+				const rawDroidEntries = await processDroidSessions(droidPath, options);
+				// Convert droid entries to LoadedUsageEntry format with Date timestamps
+				droidEntries = await Promise.all(rawDroidEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
+					timestamp: new Date(entry.timestamp),
+					usage: {
+						inputTokens: entry.message.usage.input_tokens,
+						outputTokens: entry.message.usage.output_tokens,
+						cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+						cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+					},
+					// Droid entries do not carry a pre-computed costUSD (the adapter
+					// delegates pricing to the shared engine), so we must compute it
+					// here with the same fetcher/mode as the Claude path. Without
+					// this, every droid session block would report $0.
+					costUSD: fetcher == null
+						? entry.costUSD ?? 0
+						: await calculateCostForEntry(entry, mode, fetcher),
+					model: entry.message.model ?? 'unknown',
+					version: entry.version ?? undefined,
+					usageLimitResetTime: undefined,
+					source: entry.source ?? 'droid',
+				})));
+				logger.info(`Loaded ${droidEntries.length} droid entries for blocks from ${droidPath}`);
+			}
+			catch (error) {
+				logger.warn(`Failed to load droid sessions for blocks: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load zcode usage from its SQLite database if available
-	const zcodeDbPath = getZcodeDbPath();
-	logger.debug(`ZCode database path for blocks: ${zcodeDbPath}`);
 	let zcodeEntries: LoadedUsageEntry[] = [];
-	if (zcodeDbPath === '') {
-		logger.debug('ZCode database path for blocks is empty');
-	}
-	else {
-		try {
-			const rawZcodeEntries = await processZcodeSessions(zcodeDbPath, options);
-			// ZCode entries do not carry a pre-computed costUSD (the adapter
-			// delegates pricing to the shared engine), so we must compute it
-			// here with the same fetcher/mode as the Claude path. Without
-			// this, every zcode session block would report $0.
-			zcodeEntries = await Promise.all(rawZcodeEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
-				timestamp: new Date(entry.timestamp),
-				usage: {
-					inputTokens: entry.message.usage.input_tokens,
-					outputTokens: entry.message.usage.output_tokens,
-					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
-					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
-				},
-				costUSD: fetcher == null
-					? entry.costUSD ?? 0
-					: await calculateCostForEntry(entry, mode, fetcher),
-				model: entry.message.model ?? 'unknown',
-				version: entry.version ?? undefined,
-				usageLimitResetTime: undefined,
-				source: entry.source ?? 'zcode',
-			})));
+	if (sourceFilter == null || sourceFilter === 'zcode') {
+		const zcodeDbPath = getZcodeDbPath();
+		logger.debug(`ZCode database path for blocks: ${zcodeDbPath}`);
+		if (zcodeDbPath === '') {
+			logger.debug('ZCode database path for blocks is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load zcode sessions for blocks: ${String(error)}`);
+		else {
+			try {
+				const rawZcodeEntries = await processZcodeSessions(zcodeDbPath, options);
+				// ZCode entries do not carry a pre-computed costUSD (the adapter
+				// delegates pricing to the shared engine), so we must compute it
+				// here with the same fetcher/mode as the Claude path. Without
+				// this, every zcode session block would report $0.
+				zcodeEntries = await Promise.all(rawZcodeEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
+					timestamp: new Date(entry.timestamp),
+					usage: {
+						inputTokens: entry.message.usage.input_tokens,
+						outputTokens: entry.message.usage.output_tokens,
+						cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+						cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+					},
+					costUSD: fetcher == null
+						? entry.costUSD ?? 0
+						: await calculateCostForEntry(entry, mode, fetcher),
+					model: entry.message.model ?? 'unknown',
+					version: entry.version ?? undefined,
+					usageLimitResetTime: undefined,
+					source: entry.source ?? 'zcode',
+				})));
+			}
+			catch (error) {
+				logger.warn(`Failed to load zcode sessions for blocks: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load Codex usage from its session JSONL logs if available
-	const codexPath = getCodexPath();
-	logger.debug(`Codex sessions path for blocks: ${codexPath}`);
 	let codexEntries: LoadedUsageEntry[] = [];
-	if (codexPath === '') {
-		logger.debug('Codex sessions path for blocks is empty');
-	}
-	else {
-		try {
-			const rawCodexEntries = await processCodexSessions(codexPath, options);
-			// Codex entries do not carry a pre-computed costUSD (the adapter
-			// delegates pricing to the shared engine), so we must compute it
-			// here with the same fetcher/mode as the Claude path. Without this,
-			// every Codex session block would report $0.
-			codexEntries = await Promise.all(rawCodexEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
-				timestamp: new Date(entry.timestamp),
-				usage: {
-					inputTokens: entry.message.usage.input_tokens,
-					outputTokens: entry.message.usage.output_tokens,
-					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
-					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
-				},
-				costUSD: fetcher == null
-					? entry.costUSD ?? 0
-					: await calculateCostForEntry(entry, mode, fetcher),
-				model: entry.message.model ?? 'unknown',
-				version: entry.version ?? undefined,
-				usageLimitResetTime: undefined,
-				source: entry.source ?? 'codex',
-			})));
+	if (sourceFilter == null || sourceFilter === 'codex') {
+		const codexPath = getCodexPath();
+		logger.debug(`Codex sessions path for blocks: ${codexPath}`);
+		if (codexPath === '') {
+			logger.debug('Codex sessions path for blocks is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load codex sessions for blocks: ${String(error)}`);
+		else {
+			try {
+				const rawCodexEntries = await processCodexSessions(codexPath, options);
+				// Codex entries do not carry a pre-computed costUSD (the adapter
+				// delegates pricing to the shared engine), so we must compute it
+				// here with the same fetcher/mode as the Claude path. Without this,
+				// every Codex session block would report $0.
+				codexEntries = await Promise.all(rawCodexEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
+					timestamp: new Date(entry.timestamp),
+					usage: {
+						inputTokens: entry.message.usage.input_tokens,
+						outputTokens: entry.message.usage.output_tokens,
+						cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+						cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+					},
+					costUSD: fetcher == null
+						? entry.costUSD ?? 0
+						: await calculateCostForEntry(entry, mode, fetcher),
+					model: entry.message.model ?? 'unknown',
+					version: entry.version ?? undefined,
+					usageLimitResetTime: undefined,
+					source: entry.source ?? 'codex',
+				})));
+			}
+			catch (error) {
+				logger.warn(`Failed to load codex sessions for blocks: ${String(error)}`);
+			}
 		}
 	}
 
@@ -2038,63 +2095,67 @@ export async function loadSessionBlockData(
 	// OpenCode messages carry a pre-calculated `cost` (emitted as costUSD by
 	// the adapter), so we honor it in `auto`/`display` mode; `calculate` mode
 	// recomputes from tokens.
-	const opencodeDbPath = getOpenCodeDbPath();
-	logger.debug(`OpenCode database path for blocks: ${opencodeDbPath}`);
 	let opencodeEntries: LoadedUsageEntry[] = [];
-	if (opencodeDbPath === '') {
-		logger.debug('OpenCode database path for blocks is empty');
-	}
-	else {
-		try {
-			const rawOpencodeEntries = await processOpenCodeSessions(opencodeDbPath, options);
-			opencodeEntries = await Promise.all(rawOpencodeEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
-				timestamp: new Date(entry.timestamp),
-				usage: {
-					inputTokens: entry.message.usage.input_tokens,
-					outputTokens: entry.message.usage.output_tokens,
-					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
-					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
-				},
-				costUSD: fetcher == null
-					? entry.costUSD ?? 0
-					: await calculateCostForEntry(entry, mode, fetcher),
-				model: entry.message.model ?? 'unknown',
-				version: entry.version ?? undefined,
-				usageLimitResetTime: undefined,
-				source: entry.source ?? 'opencode',
-			})));
+	if (sourceFilter == null || sourceFilter === 'opencode') {
+		const opencodeDbPath = getOpenCodeDbPath();
+		logger.debug(`OpenCode database path for blocks: ${opencodeDbPath}`);
+		if (opencodeDbPath === '') {
+			logger.debug('OpenCode database path for blocks is empty');
 		}
-		catch (error) {
-			logger.warn(`Failed to load opencode sessions for blocks: ${String(error)}`);
+		else {
+			try {
+				const rawOpencodeEntries = await processOpenCodeSessions(opencodeDbPath, options);
+				opencodeEntries = await Promise.all(rawOpencodeEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
+					timestamp: new Date(entry.timestamp),
+					usage: {
+						inputTokens: entry.message.usage.input_tokens,
+						outputTokens: entry.message.usage.output_tokens,
+						cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+						cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+					},
+					costUSD: fetcher == null
+						? entry.costUSD ?? 0
+						: await calculateCostForEntry(entry, mode, fetcher),
+					model: entry.message.model ?? 'unknown',
+					version: entry.version ?? undefined,
+					usageLimitResetTime: undefined,
+					source: entry.source ?? 'opencode',
+				})));
+			}
+			catch (error) {
+				logger.warn(`Failed to load opencode sessions for blocks: ${String(error)}`);
+			}
 		}
 	}
 
 	// Also load Devin usage from its ATIF transcripts if available
-	const devinPath = getDevinPath();
-	logger.debug(`Devin data directory: ${devinPath}`);
 	let devinEntries: LoadedUsageEntry[] = [];
-	if (devinPath !== '') {
-		try {
-			const rawDevinEntries = await processDevinSessions(devinPath, options);
-			devinEntries = await Promise.all(rawDevinEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
-				timestamp: new Date(entry.timestamp),
-				usage: {
-					inputTokens: entry.message.usage.input_tokens,
-					outputTokens: entry.message.usage.output_tokens,
-					cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
-					cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
-				},
-				costUSD: fetcher == null
-					? entry.costUSD ?? 0
-					: await calculateCostForEntry(entry, mode, fetcher),
-				model: entry.message.model ?? 'unknown',
-				version: entry.version ?? undefined,
-				usageLimitResetTime: undefined,
-				source: entry.source ?? 'devin',
-			})));
-		}
-		catch (error) {
-			logger.warn(`Failed to load devin sessions: ${String(error)}`);
+	if (sourceFilter == null || sourceFilter === 'devin') {
+		const devinPath = getDevinPath();
+		logger.debug(`Devin data directory: ${devinPath}`);
+		if (devinPath !== '') {
+			try {
+				const rawDevinEntries = await processDevinSessions(devinPath, options);
+				devinEntries = await Promise.all(rawDevinEntries.map(async (entry): Promise<LoadedUsageEntry> => ({
+					timestamp: new Date(entry.timestamp),
+					usage: {
+						inputTokens: entry.message.usage.input_tokens,
+						outputTokens: entry.message.usage.output_tokens,
+						cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+						cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+					},
+					costUSD: fetcher == null
+						? entry.costUSD ?? 0
+						: await calculateCostForEntry(entry, mode, fetcher),
+					model: entry.message.model ?? 'unknown',
+					version: entry.version ?? undefined,
+					usageLimitResetTime: undefined,
+					source: entry.source ?? 'devin',
+				})));
+			}
+			catch (error) {
+				logger.warn(`Failed to load devin sessions: ${String(error)}`);
+			}
 		}
 	}
 

--- a/apps/better-ccusage/src/devin-adapter.ts
+++ b/apps/better-ccusage/src/devin-adapter.ts
@@ -384,23 +384,27 @@ export function getDevinPath(): string {
  * hidden sessions. User-input steps and zero-token steps are skipped.
  *
  * @param dataDir - Absolute path to the Devin CLI data directory
- * @param _options - Load options (kept for parity with the other adapters)
+ * @param options - Load options. `options.source` gates the "transcripts
+ *   directory not found" warning so it only fires when the user explicitly
+ *   asked for devin.
  * @returns Transformed usage entries (one per billable step)
  */
 export async function processDevinSessions(
 	dataDir: string,
-	_options: LoadOptions = {},
+	options: LoadOptions = {},
 ): Promise<UsageData[]> {
 	if (dataDir === '') {
 		logger.debug('Devin data directory is empty, skipping');
 		return [];
 	}
 
+	// Warn loudly only when the user explicitly asked for devin; in aggregate
+	// mode a machine that doesn't use Devin must stay quiet.
+	const optedIn = options.source === 'devin';
+
 	const transcriptsDir = path.join(dataDir, DEVIN_TRANSCRIPTS_SUBPATH);
 	if (!existsSync(transcriptsDir)) {
-		// warn (not debug): a missing transcripts dir is the most common reason
-		// Devin data is invisible in reports, and debug is hidden by default.
-		logger.warn(`Devin transcripts directory not found at ${transcriptsDir}`);
+		(optedIn ? logger.warn : logger.debug)(`Devin transcripts directory not found at ${transcriptsDir}`);
 		return [];
 	}
 

--- a/apps/better-ccusage/src/devin-adapter.ts
+++ b/apps/better-ccusage/src/devin-adapter.ts
@@ -398,7 +398,9 @@ export async function processDevinSessions(
 
 	const transcriptsDir = path.join(dataDir, DEVIN_TRANSCRIPTS_SUBPATH);
 	if (!existsSync(transcriptsDir)) {
-		logger.debug(`Devin transcripts directory not found at ${transcriptsDir}`);
+		// warn (not debug): a missing transcripts dir is the most common reason
+		// Devin data is invisible in reports, and debug is hidden by default.
+		logger.warn(`Devin transcripts directory not found at ${transcriptsDir}`);
 		return [];
 	}
 
@@ -544,7 +546,16 @@ export async function processDevinSessions(
 		}
 	}
 
-	logger.info(`Loaded ${results.length} Devin usage entries from ${transcriptsDir}`);
+	logger.info(`Loaded ${results.length} Devin usage entries from ${transcriptsDir} (${files.length} transcript file${files.length === 1 ? '' : 's'})`);
+
+	// Surface the "transcripts exist but nothing extracted" case so Devin being
+	// invisible in reports is diagnosable instead of silent.
+	if (results.length === 0 && files.length > 0) {
+		logger.warn(
+			`Devin transcripts directory at ${transcriptsDir} had ${files.length} file(s) but none yielded usage entries. Transcripts without token/step data or with an unrecognized schema are skipped.`,
+		);
+	}
+
 	return results;
 }
 

--- a/apps/better-ccusage/src/opencode-adapter.ts
+++ b/apps/better-ccusage/src/opencode-adapter.ts
@@ -178,7 +178,9 @@ export async function processOpenCodeSessions(
 	}
 
 	if (!existsSync(dbPath)) {
-		logger.debug(`OpenCode database not found at ${dbPath}`);
+		// warn (not debug): a missing DB is the most common reason OpenCode
+		// data is invisible in reports, and debug is hidden by default.
+		logger.warn(`OpenCode database not found at ${dbPath}`);
 		return [];
 	}
 
@@ -306,7 +308,16 @@ export async function processOpenCodeSessions(
 		results.push(entry);
 	}
 
-	logger.info(`Loaded ${results.length} OpenCode usage entries from ${dbPath}`);
+	logger.info(`Loaded ${results.length} OpenCode usage entries from ${dbPath} (${rows.length} message row${rows.length === 1 ? '' : 's'})`);
+
+	// Surface the "data exists but nothing extracted" case so OpenCode being
+	// invisible in reports is diagnosable instead of silent.
+	if (results.length === 0 && rows.length > 0) {
+		logger.warn(
+			`OpenCode database at ${dbPath} had ${rows.length} message row(s) but none yielded usage entries. Rows without token usage, with all-zero tokens, or without a model id are skipped.`,
+		);
+	}
+
 	return results;
 }
 

--- a/apps/better-ccusage/src/opencode-adapter.ts
+++ b/apps/better-ccusage/src/opencode-adapter.ts
@@ -165,22 +165,25 @@ const MESSAGES_SQL = `
  * recomputes from tokens via the shared engine.
  *
  * @param dbPath - Absolute path to the OpenCode SQLite database
- * @param _options - Load options (kept for parity with the other adapters)
+ * @param options - Load options. `options.source` gates the "database not
+ *   found" warning so it only fires when the user explicitly asked for opencode.
  * @returns Transformed usage entries (one per assistant message with tokens)
  */
 export async function processOpenCodeSessions(
 	dbPath: string,
-	_options: LoadOptions = {},
+	options: LoadOptions = {},
 ): Promise<UsageData[]> {
 	if (dbPath === '') {
 		logger.debug('OpenCode database path is empty, skipping');
 		return [];
 	}
 
+	// Warn loudly only when the user explicitly asked for opencode; in aggregate
+	// mode a machine that doesn't use OpenCode must stay quiet.
+	const optedIn = options.source === 'opencode';
+
 	if (!existsSync(dbPath)) {
-		// warn (not debug): a missing DB is the most common reason OpenCode
-		// data is invisible in reports, and debug is hidden by default.
-		logger.warn(`OpenCode database not found at ${dbPath}`);
+		(optedIn ? logger.warn : logger.debug)(`OpenCode database not found at ${dbPath}`);
 		return [];
 	}
 

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -30,15 +30,17 @@
     "test": "TZ=UTC vitest run",
     "typecheck": "tsgo --noEmit"
   },
+  "dependencies": {
+    "better-ccusage": "workspace:*",
+    "nano-spawn": "catalog:runtime"
+  },
   "devDependencies": {
     "@better-ccusage/internal": "workspace:*",
     "@better-ccusage/terminal": "workspace:*",
     "@ryoppippi/eslint-config": "catalog:lint",
     "@typescript/native-preview": "catalog:types",
-    "better-ccusage": "workspace:*",
     "clean-pkg-json": "catalog:release",
     "eslint": "catalog:lint",
-    "nano-spawn": "catalog:runtime",
     "tsdown": "catalog:",
     "unplugin-macros": "catalog:build",
     "unplugin-unused": "catalog:build",

--- a/apps/codex/src/resolve-better-ccusage.ts
+++ b/apps/codex/src/resolve-better-ccusage.ts
@@ -1,6 +1,5 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 const nodeRequire = createRequire(import.meta.url);
 
@@ -9,29 +8,23 @@ type BinField = string | Record<string, string> | undefined;
 /**
  * Resolve the `better-ccusage` binary entry path.
  *
- * In a published install, `better-ccusage` is expected to be resolvable
- * alongside this package (e.g. installed as a sibling workspace dep). Falls
- * back to the monorepo sibling source during development so the shim works
- * without a published build.
+ * `better-ccusage` must be resolvable alongside this package: it is declared
+ * as a runtime `dependency` in package.json, so in a published install it is a
+ * sibling under `node_modules/better-ccusage`, and in the monorepo it resolves
+ * through the pnpm workspace symlink. There is intentionally no fallback: a
+ * previous hardcoded `../../better-ccusage/src/index.ts` path shipped to npm
+ * and caused a silent `MODULE_NOT_FOUND` because `src/` is not published. Fail
+ * loudly instead so misconfiguration is obvious.
  */
 export function resolveBinaryPath(): string {
-	// First try the published workspace package.
-	try {
-		const packageJsonPath = nodeRequire.resolve('better-ccusage/package.json');
-		const packageJson = nodeRequire(packageJsonPath) as { bin?: BinField; publishConfig?: { bin?: BinField } };
-		const binField: BinField = packageJson.bin ?? packageJson.publishConfig?.bin;
-		const binRelative = typeof binField === 'string'
-			? binField
-			: (binField != null ? (binField['better-ccusage'] ?? Object.values(binField)[0]) : undefined);
-		if (binRelative != null) {
-			return path.resolve(path.dirname(packageJsonPath), binRelative);
-		}
+	const packageJsonPath = nodeRequire.resolve('better-ccusage/package.json');
+	const packageJson = nodeRequire(packageJsonPath) as { bin?: BinField; publishConfig?: { bin?: BinField } };
+	const binField: BinField = packageJson.bin ?? packageJson.publishConfig?.bin;
+	const binRelative = typeof binField === 'string'
+		? binField
+		: (binField != null ? (binField['better-ccusage'] ?? Object.values(binField)[0]) : undefined);
+	if (binRelative == null) {
+		throw new Error(`better-ccusage package.json at ${packageJsonPath} has no resolvable bin field`);
 	}
-	catch {
-		// Fall through to development fallback below.
-	}
-
-	// Development fallback: monorepo sibling (apps/better-ccusage/src/index.ts).
-	const currentDir = path.dirname(fileURLToPath(import.meta.url));
-	return path.resolve(currentDir, '..', '..', 'better-ccusage', 'src', 'index.ts');
+	return path.resolve(path.dirname(packageJsonPath), binRelative);
 }

--- a/apps/opencode/package.json
+++ b/apps/opencode/package.json
@@ -30,14 +30,16 @@
     "test": "TZ=UTC vitest run",
     "typecheck": "tsgo --noEmit"
   },
+  "dependencies": {
+    "better-ccusage": "workspace:*",
+    "nano-spawn": "catalog:runtime"
+  },
   "devDependencies": {
     "@praha/byethrow": "catalog:runtime",
     "@ryoppippi/eslint-config": "catalog:lint",
     "@typescript/native-preview": "catalog:types",
-    "better-ccusage": "workspace:*",
     "clean-pkg-json": "catalog:release",
     "eslint": "catalog:lint",
-    "nano-spawn": "catalog:runtime",
     "tsdown": "catalog:",
     "unplugin-macros": "catalog:build",
     "unplugin-unused": "catalog:build",

--- a/apps/opencode/src/resolve-better-ccusage.ts
+++ b/apps/opencode/src/resolve-better-ccusage.ts
@@ -1,6 +1,5 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { Result } from '@praha/byethrow';
 
 const nodeRequire = createRequire(import.meta.url);
@@ -10,16 +9,16 @@ type BinField = string | Record<string, string> | undefined;
 /**
  * Resolve the `better-ccusage` binary entry path.
  *
- * In a published install, `better-ccusage` is expected to be resolvable
- * alongside this package (e.g. installed as a sibling workspace dep). Falls
- * back to the monorepo sibling source during development so the shim works
- * without a published build.
+ * `better-ccusage` must be resolvable alongside this package: it is declared
+ * as a runtime `dependency` in package.json, so in a published install it is a
+ * sibling under `node_modules/better-ccusage`, and in the monorepo it resolves
+ * through the pnpm workspace symlink. There is intentionally no fallback: a
+ * previous hardcoded `../../better-ccusage/src/index.ts` path shipped to npm
+ * and caused a silent `MODULE_NOT_FOUND` because `src/` is not published. Fail
+ * loudly instead so misconfiguration is obvious.
  *
- * The whole resolution block (resolve + read package.json + read bin field)
- * is wrapped in a single `Result.try` so that ANY failure — missing package,
- * corrupt package.json, missing/malformed bin field — falls back to the dev
- * path rather than crashing the forwarder. This preserves the original
- * try-catch safety net while following the coding guideline to prefer Result.
+ * The resolution block is wrapped in `Result.try` to follow the repo's Result
+ * convention, then unwrapped: a failure here is unrecoverable for the shim.
  */
 export async function resolveBinaryPath(): Promise<string> {
 	const resolved = Result.try({
@@ -31,18 +30,19 @@ export async function resolveBinaryPath(): Promise<string> {
 				? binField
 				: (binField != null ? (binField['better-ccusage'] ?? Object.values(binField)[0]) : undefined);
 			if (binRelative == null) {
-				throw new Error('better-ccusage package.json has no resolvable bin field');
+				throw new Error(`better-ccusage package.json at ${packageJsonPath} has no resolvable bin field`);
 			}
 			return path.resolve(path.dirname(packageJsonPath), binRelative);
 		},
 		catch: error => error,
 	})();
 
-	if (Result.isSuccess(resolved)) {
-		return resolved.value;
+	if (Result.isFailure(resolved)) {
+		// No silent fallback: surface the resolution failure so it can be fixed.
+		throw new Error(
+			`Could not resolve better-ccusage. Ensure the 'better-ccusage' package is installed (declared as a dependency of @better-ccusage/opencode). Underlying error: ${String(resolved.error)}`,
+		);
 	}
 
-	// Development fallback: monorepo sibling (apps/better-ccusage/src/index.ts).
-	const currentDir = path.dirname(fileURLToPath(import.meta.url));
-	return path.resolve(currentDir, '..', '..', 'better-ccusage', 'src', 'index.ts');
+	return resolved.value;
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -68,15 +68,11 @@ export default defineConfig({
 					],
 				},
 				{
-					text: 'Codex Source',
+					text: 'Data Sources',
 					items: [
-						{ text: 'Overview', link: '/guide/codex/' },
-					],
-				},
-				{
-					text: 'Devin Source',
-					items: [
-						{ text: 'Overview', link: '/guide/devin' },
+						{ text: 'Codex', link: '/guide/codex/' },
+						{ text: 'OpenCode', link: '/guide/opencode' },
+						{ text: 'Devin', link: '/guide/devin' },
 					],
 				},
 				{

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -15,6 +15,16 @@ npx better-ccusage session
 
 Codex rows are labeled with the `codex` source in combined reports. You get the same Daily / Weekly / Monthly / Session / Blocks commands as for every other source.
 
+### Codex-only reports
+
+To see Codex usage on its own (excluding Claude, Droid, etc.), use the `<source> <report>` syntax:
+
+```bash
+npx better-ccusage codex daily       # Codex-only daily report
+npx better-ccusage codex blocks      # Codex-only billing blocks
+npx better-ccusage codex             # shorthand for "codex daily"
+```
+
 ## Backward compatibility
 
 The `@better-ccusage/codex` package still works as a thin forwarder:

--- a/docs/guide/devin.md
+++ b/docs/guide/devin.md
@@ -27,6 +27,16 @@ npx better-ccusage blocks
 
 The `Source` column in the output shows `devin` for entries parsed from Devin transcripts.
 
+### Devin-only reports
+
+To see Devin usage on its own (excluding Claude, Droid, etc.), use the `<source> <report>` syntax:
+
+```bash
+npx better-ccusage devin daily       # Devin-only daily report
+npx better-ccusage devin session     # Devin-only session report
+npx better-ccusage devin             # shorthand for "devin daily"
+```
+
 ## Data Location
 
 The Devin CLI writes its data under a platform-specific directory:

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -90,6 +90,43 @@ ZCode (the official GLM coding tool) records every model request in this databas
 Reading the ZCode database requires Node.js `>=22.13.0` (when the built-in `node:sqlite` module stopped requiring the `--experimental-sqlite` flag). On older Node versions or alternative runtimes (e.g. Bun), ZCode data is silently skipped and Claude/Droid usage continues to work normally.
 :::
 
+## DROID_SESSIONS_DIR
+
+Specifies the directory where Factory/Droid stores its session data.
+
+```bash
+export DROID_SESSIONS_DIR="/path/to/your/factory/sessions"
+better-ccusage daily
+```
+
+When not set, better-ccusage looks in `~/.factory/sessions` by default.
+
+## CODEX_HOME
+
+Overrides the OpenAI Codex CLI home directory. `better-ccusage` reads session JSONL logs from `<CODEX_HOME>/sessions` (recursively, matching `**/*.jsonl`).
+
+```bash
+export CODEX_HOME="/path/to/your/codex/home"
+better-ccusage daily
+```
+
+When not set, the default is `~/.codex` (so sessions are read from `~/.codex/sessions`).
+
+::: tip
+Interactive Codex TUI sessions do not write per-turn `token_count` events to disk — only `codex exec` (non-interactive) does. If your Codex usage is missing, run `better-ccusage codex daily` and check the diagnostic warning. See [openai/codex#9660](https://github.com/openai/codex/issues/9660) for background.
+:::
+
+## OPENCODE_DATA_DIR
+
+Overrides the OpenCode data directory. `better-ccusage` reads the `opencode.db` SQLite database from this directory.
+
+```bash
+export OPENCODE_DATA_DIR="/path/to/your/opencode"
+better-ccusage daily
+```
+
+When not set, the default is `~/.local/share/opencode`.
+
 ## DEVIN_DATA_DIR
 
 Specifies the Devin CLI data directory where better-ccusage should look for ATIF trajectory transcripts (`transcripts/*.json`) and the optional `sessions.db` enrichment database.

--- a/docs/guide/opencode.md
+++ b/docs/guide/opencode.md
@@ -1,151 +1,48 @@
 # OpenCode Usage Tracking
 
-better-ccusage provides usage tracking for [OpenCode](https://github.com/sst/opencode), a terminal-based AI coding assistant. This allows you to monitor token usage and costs when using OpenCode with various AI providers.
+`better-ccusage` reads [OpenCode](https://github.com/sst/opencode) usage directly from its SQLite database and aggregates it alongside Claude, Droid, ZCode, Codex, and Devin data — no separate package required.
 
-## Installation
+> ⚠️ The standalone `@better-ccusage/opencode` package is **deprecated** and only forwards invocations to `better-ccusage`. Run `better-ccusage` directly.
 
-```bash
-# Install the opencode package
-pnpm add @better-ccusage/opencode
+## Where the data comes from
 
-# Or use directly with npx
-pnpm dlx @better-ccusage/opencode daily
-```
+OpenCode stores per-message token usage in a SQLite database. `better-ccusage` reads it (read-only) from:
+
+- Default: `~/.local/share/opencode/opencode.db`
+- Override with the `OPENCODE_DATA_DIR` environment variable (points at the directory that contains `opencode.db`).
+
+Each assistant message with a non-zero token count becomes one usage entry. `tokens.input` already excludes cached tokens, so the Claude additive cost model applies directly; OpenCode's reasoning-token surplus is folded into `output_tokens` (matching upstream `ccusage`).
 
 ## Usage
 
-### Daily Reports
+By default every report aggregates all detected sources. To see OpenCode usage only, use the `<source> <report>` syntax:
 
 ```bash
-pnpm dlx @better-ccusage/opencode daily
+# OpenCode-only daily report
+npx better-ccusage opencode daily
+
+# OpenCode-only billing blocks
+npx better-ccusage opencode blocks
+
+# OpenCode-only session report
+npx better-ccusage opencode session
+
+# Shorthand: 'opencode' alone defaults to 'opencode daily'
+npx better-ccusage opencode
 ```
 
-Shows token usage and costs aggregated by day.
+The equivalent explicit form also works (`npx better-ccusage daily --source opencode`), but the positional form above is preferred. See the [Command-Line Options](/guide/cli-options.md) page for the full flag list.
 
-### Weekly Reports
+## Troubleshooting
 
-```bash
-pnpm dlx @better-ccusage/opencode weekly
-```
+If OpenCode data is missing from your reports, `better-ccusage` now warns when:
 
-Shows usage aggregated by ISO week (format: `YYYY-Www`).
-
-### Monthly Reports
-
-```bash
-pnpm dlx @better-ccusage/opencode monthly
-```
-
-Shows usage aggregated by month (format: `YYYY-MM`).
-
-### Session Reports
-
-```bash
-pnpm dlx @better-ccusage/opencode session
-```
-
-Shows usage grouped by session, with subagent hierarchy displayed.
-
-## Command Options
-
-| Option        | Short | Description                            |
-| ------------- | ----- | -------------------------------------- |
-| `--breakdown` | `-b`  | Show per-model cost breakdown          |
-| `--compact`   |       | Force compact mode for narrow displays |
-
-## Data Location
-
-OpenCode stores its data in:
-
-- **Messages**: `~/.local/share/opencode/storage/message/{sessionID}/msg_{id}.json`
-- **Sessions**: `~/.local/share/opencode/storage/session/{sessionID}.json`
-
-### Custom Data Directory
-
-You can override the data directory using environment variables:
-
-```bash
-# Use custom data directory
-export OPENCODE_DATA_DIR=/custom/path/to/opencode
-
-# Or use XDG Base Directory specification
-export XDG_DATA_HOME=/custom/xdg/data
-```
-
-## Supported Models
-
-OpenCode supports various AI providers. better-ccusage automatically detects and calculates costs for:
-
-- **Anthropic**: Claude models (claude-sonnet-4, claude-opus-4, etc.)
-- **Google**: Gemini models
-- **OpenAI**: GPT models
-- **Other providers**: Any model in the pricing database
-
-### Model Aliases
-
-Some OpenCode-specific model names are automatically mapped to standard pricing names:
-
-| OpenCode Name       | Pricing Database Name    |
-| ------------------- | ------------------------ |
-| `gemini-3-pro-high` | `gemini-3-pro-preview`   |
-| `gemini-2.5-pro`    | `gemini-2.5-pro-preview` |
-
-## Key Differences from Claude Code
-
-| Feature               | Claude Code               | OpenCode                            |
-| --------------------- | ------------------------- | ----------------------------------- |
-| **Data Format**       | JSONL files               | JSON files                          |
-| **Storage Location**  | `~/.claude/projects/`     | `~/.local/share/opencode/storage/`  |
-| **Cost Calculation**  | Pre-calculated `costUSD`  | Often needs calculation from tokens |
-| **Subagent Tracking** | Via `parentID` in entries | Via `parentID` in session metadata  |
-
-## Output Format
-
-### Table Output
-
-Default output shows a formatted table with:
-
-- Date/Week/Month or Session ID
-- Source (opencode)
-- Models used
-- Input/Output tokens
-- Cache creation/read tokens
-- Total tokens
-- Cost (USD)
-
-### Example
-
-```
-┌────────────┬──────────┬────────┬───────┬────────┬──────────────┬────────────┬──────────────┬────────────┐
-│ Date       │ Source   │ Models │ Input │ Output │ Cache Create │ Cache Read │ Total Tokens │ Cost (USD) │
-├────────────┼──────────┼────────┼───────┼────────┼──────────────┼────────────┼──────────────┼────────────┤
-│ 2026-02-14 │ opencode │ claude │ 1,234 │ 567    │ 100          │ 50         │ 1,951        │ $0.0234    │
-└────────────┴──────────┴────────┴───────┴────────┴──────────────┴────────────┴──────────────┴────────────┘
-```
-
-## Library Usage
-
-You can also use the package programmatically:
-
-```typescript
-import { loadDailyUsageData, loadMonthlyUsageData, loadWeeklyUsageData } from '@better-ccusage/opencode/data-loader';
-
-// Load daily usage data
-const dailyData = await loadDailyUsageData();
-console.log(dailyData);
-
-// Load weekly usage data
-const weeklyData = await loadWeeklyUsageData();
-console.log(weeklyData);
-
-// Load monthly usage data
-const monthlyData = await loadMonthlyUsageData();
-console.log(monthlyData);
-```
+- The OpenCode database is not found at the expected path — check `OPENCODE_DATA_DIR` or the default `~/.local/share/opencode/opencode.db`.
+- The database exists and has message rows, but none yielded usage entries — messages without token usage, with all-zero tokens, or without a model id are skipped.
 
 ## Related
 
 - [Daily Reports](/guide/daily-reports.md)
-- [Weekly Reports](/guide/weekly-reports.md)
-- [Monthly Reports](/guide/monthly-reports.md)
 - [Session Reports](/guide/session-reports.md)
+- [Blocks Reports](/guide/blocks-reports.md)
+- [Environment Variables](/guide/environment-variables.md)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,13 @@ importers:
         version: 5.1.0
 
   apps/codex:
+    dependencies:
+      better-ccusage:
+        specifier: workspace:*
+        version: link:../better-ccusage
+      nano-spawn:
+        specifier: catalog:runtime
+        version: 1.0.3
     devDependencies:
       '@better-ccusage/internal':
         specifier: workspace:*
@@ -325,18 +332,12 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20251201.1
-      better-ccusage:
-        specifier: workspace:*
-        version: link:../better-ccusage
       clean-pkg-json:
         specifier: catalog:release
         version: 1.4.1
       eslint:
         specifier: catalog:lint
         version: 9.39.1(jiti@2.6.1)
-      nano-spawn:
-        specifier: catalog:runtime
-        version: 1.0.3
       tsdown:
         specifier: 'catalog:'
         version: 0.16.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.1)(@typescript/native-preview@7.0.0-dev.20251201.1)(publint@0.3.18)(synckit@0.11.11)(typescript@5.9.3)(unplugin-unused@0.5.7)
@@ -408,6 +409,13 @@ importers:
         version: 3.25.76
 
   apps/opencode:
+    dependencies:
+      better-ccusage:
+        specifier: workspace:*
+        version: link:../better-ccusage
+      nano-spawn:
+        specifier: catalog:runtime
+        version: 1.0.3
     devDependencies:
       '@praha/byethrow':
         specifier: catalog:runtime
@@ -418,18 +426,12 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:types
         version: 7.0.0-dev.20251201.1
-      better-ccusage:
-        specifier: workspace:*
-        version: link:../better-ccusage
       clean-pkg-json:
         specifier: catalog:release
         version: 1.4.1
       eslint:
         specifier: catalog:lint
         version: 9.39.1(jiti@2.6.1)
-      nano-spawn:
-        specifier: catalog:runtime
-        version: 1.0.3
       tsdown:
         specifier: 'catalog:'
         version: 0.16.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.1)(@typescript/native-preview@7.0.0-dev.20251201.1)(publint@0.3.18)(synckit@0.11.11)(typescript@5.9.3)(unplugin-unused@0.5.7)


### PR DESCRIPTION
## Summary

Fixes four user-facing issues reported together, plus adds the CLI smoke-test coverage that let them ship undetected.

### 1. `better-ccusage codex` threw a raw `Command not found` stack trace
gunshi 0.26.3 treated the source name as an unknown subcommand. There was no way to filter reports to a single data source.

**Fix:** positional source syntax mirroring upstream ccusage:
```bash
better-ccusage codex daily       # Codex-only daily report
better-ccusage opencode blocks   # OpenCode-only billing blocks
better-ccusage devin             # shorthand for 'devin daily'
```
Implemented via argv rewrite in `run()` (gunshi has no nested-subcommand/alias support), a `source` field threaded through `LoadOptions`, and per-adapter gates in all 3 loaders (`loadDailyUsageData`, `loadSessionData`, `loadSessionBlockData`). `getClaudePaths()` is short-circuited when filtering to a non-claude source so it no longer throws on machines without Claude data. Unknown commands now produce a friendly message (listing valid commands + sources) and exit 1 instead of a stack trace.

### 2. `npx @better-ccusage/{codex,opencode}` crashed with `MODULE_NOT_FOUND`
`better-ccusage` and `nano-spawn` were declared in `devDependencies` (stripped by `clean-pkg-json` at publish), so `require.resolve('better-ccusage/package.json')` threw and the resolver fell back to an unshipped `../../better-ccusage/src/index.ts`.

**Fix:** move both to a runtime `dependencies` block; replace the broken fallback with an explicit throw.

### 3. Codex data invisible in `--breakdown`
Interactive Codex TUI sessions do not write per-turn `token_count` events to the rollout JSONL ([openai/codex#9660](https://github.com/openai/codex/issues/9660)). The adapter silently returned `[]` with only debug-level logs (11 drop-points, all hidden by default).

**Fix:** the codex/opencode/devin adapters now warn when a source the user explicitly opted into is missing, and emit one actionable diagnostic pointing at #9660 when a session file has `token_count` events but none with usable usage data. In aggregate mode (no `--source`), missing-source warnings stay at `debug` so a Claude-only user isn't flooded with spurious warns (review feedback).

### 4. Zero CLI smoke tests
The CLI entry point (`commands/index.ts`) had no test coverage, which is why #1 and #3 shipped.

**Fix:** 35 new smoke tests covering `rewriteArgv` (all 6 sources × report/no-report/flags), the friendly unknown-command error, and `run()` dispatch with gunshi mocked.

### Plus docs
README tagline/comparison/examples updated; `docs/guide/opencode.md` rewritten (was stale — recommended the deprecated package and a wrong storage path); env-var reference completed (`CODEX_HOME`, `OPENCODE_DATA_DIR`, `DROID_SESSIONS_DIR`); vitepress sidebar regroups sources.

## Validation
- `pnpm typecheck` ✓ (all 5 packages)
- `pnpm lint` ✓ (clean)
- `pnpm test` ✓ 355/355 (was 320; +35 smoke tests)
- Runtime-verified: `better-ccusage codex daily` shows codex-only data; `foobar` exits 1 with friendly message; both shims forward correctly; aggregated `daily` is silent about missing devin/opencode.

## Notes
- `--source` is exposed as a visible flag (gunshi 0.26.3 ignores `hidden`); description points at the preferred positional form.
- The deprecated shim packages need a version bump + republish for the fix to reach `npx @better-ccusage/codex@latest` — code is ready.
- One review nit left as-is: the defensive gunshi `Command not found:` catch branch is technically unreachable (`rewriteArgv` handles it first) but kept as belt-and-suspenders.

🤖 Generated with [ZCode](https://zcode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added filtering for reports by data source, including Claude, Droid, ZCode, Codex, OpenCode, and Devin.
  - Added positional source syntax, such as `codex daily`, with daily reports as the default.
  - Improved source-specific messaging and diagnostics for empty or unavailable data.

- **Bug Fixes**
  - Improved handling and warnings for unsupported or incomplete Codex, Devin, and OpenCode usage data.
  - Unknown commands and sources now produce clearer error messages.

- **Documentation**
  - Expanded guides for data sources, environment variables, and source-specific reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->