### PR TITLE
docs: add audit-grade snapshot workflow for billing reconciliation

### DIFF
--- a/docs/guide/directory-detection.md
+++ b/docs/guide/directory-detection.md
@@ -129,7 +129,7 @@ export CLAUDE_CONFIG_DIR="$SNAP/config,$SNAP/legacy"
 better-ccusage monthly --breakdown   # totals as of the snapshot date
 ```
 
-If you only have one root (e.g. a fresh install on `~/.config/claude`), the `CLAUDE_CONFIG_DIR` list naturally contains just that one path. Keep snapshots around for as long as you need auditable numbers; they're plain JSONL files, so they compress well. See [#40](https://github.com/cobra91/better-ccusage/issues/40) for the original field report and repro.
+If you only have one root (e.g. a fresh install on `~/.config/claude`), `rmdir` removes the empty stub for the missing root and better-ccusage silently skips it, so the report still runs against the one root you copied (the stale entry in `CLAUDE_CONFIG_DIR` simply won't resolve). Keep snapshots around for as long as you need auditable numbers; they're plain JSONL files, so they compress well. See [#40](https://github.com/cobra91/better-ccusage/issues/40) for the original field report and repro.
 
 ## Related Documentation
 

--- a/docs/guide/directory-detection.md
+++ b/docs/guide/directory-detection.md
@@ -112,20 +112,24 @@ LOG_LEVEL=4 better-ccusage daily
 
 Claude Code rewrites session JSONL files when you `resume` or `compact` a session, and in doing so can drop or rewrite earlier messages. Because better-ccusage reads those files faithfully, totals computed after a rewrite can drift from what you actually used earlier — historical usage that was compacted away is gone from the source.
 
-This is an [upstream Claude Code behavior](https://github.com/anthropics/claude-code/issues/36583), not a better-ccusage bug, and better-ccusage intentionally does not reconstruct a different history (no shadow ledger). For billing reconciliation or audit-grade totals, snapshot the Claude data directory before resuming/compacting long sessions, then point `CLAUDE_CONFIG_DIR` at the snapshot when you need an accurate-as-of-then report:
+This is an [upstream Claude Code behavior](https://github.com/anthropics/claude-code/issues/36583), not a better-ccusage bug, and better-ccusage intentionally does not reconstruct a different history (no shadow ledger). For billing reconciliation or audit-grade totals, snapshot the Claude data directory before resuming/compacting long sessions, then point `CLAUDE_CONFIG_DIR` at the snapshot when you need an accurate-as-of-then report.
+
+better-ccusage aggregates **both** Claude data roots by default — the new `~/.config/claude/projects/` and the legacy `~/.claude/projects/` (see [Default Directory Locations](#default-directory-locations)). A correct snapshot must capture each root that exists on your machine, then report against all of them via a comma-separated `CLAUDE_CONFIG_DIR`:
 
 ```bash
-# 1. Snapshot the current Claude data (do this before resume/compact)
+# 1. Snapshot every Claude data root that exists (do this before resume/compact)
 SNAP="$HOME/claude-snapshots/$(date +%Y%m%d-%H%M%S)"
-mkdir -p "$SNAP"
-cp -r ~/.config/claude/projects "$SNAP/projects"
+mkdir -p "$SNAP/config" "$SNAP/legacy"
+# Copy each existing root; ignore the ones you don't have.
+cp -r ~/.config/claude/projects "$SNAP/config/projects" 2>/dev/null || rmdir "$SNAP/config"
+cp -r ~/.claude/projects       "$SNAP/legacy/projects" 2>/dev/null || rmdir "$SNAP/legacy"
 
-# 2. Later, run reports against the frozen snapshot
-export CLAUDE_CONFIG_DIR="$SNAP"
+# 2. Later, run reports against the frozen snapshot (list every root you copied)
+export CLAUDE_CONFIG_DIR="$SNAP/config,$SNAP/legacy"
 better-ccusage monthly --breakdown   # totals as of the snapshot date
 ```
 
-Keep snapshots around for as long as you need auditable numbers; they're plain JSONL files, so they compress well. See [#40](https://github.com/cobra91/better-ccusage/issues/40) for the original field report and repro.
+If you only have one root (e.g. a fresh install on `~/.config/claude`), the `CLAUDE_CONFIG_DIR` list naturally contains just that one path. Keep snapshots around for as long as you need auditable numbers; they're plain JSONL files, so they compress well. See [#40](https://github.com/cobra91/better-ccusage/issues/40) for the original field report and repro.
 
 ## Related Documentation
 

--- a/docs/guide/directory-detection.md
+++ b/docs/guide/directory-detection.md
@@ -108,6 +108,25 @@ better-ccusage daily
 LOG_LEVEL=4 better-ccusage daily
 ```
 
+## Audit-grade reports (snapshot before resume/compact)
+
+Claude Code rewrites session JSONL files when you `resume` or `compact` a session, and in doing so can drop or rewrite earlier messages. Because better-ccusage reads those files faithfully, totals computed after a rewrite can drift from what you actually used earlier — historical usage that was compacted away is gone from the source.
+
+This is an [upstream Claude Code behavior](https://github.com/anthropics/claude-code/issues/36583), not a better-ccusage bug, and better-ccusage intentionally does not reconstruct a different history (no shadow ledger). For billing reconciliation or audit-grade totals, snapshot the Claude data directory before resuming/compacting long sessions, then point `CLAUDE_CONFIG_DIR` at the snapshot when you need an accurate-as-of-then report:
+
+```bash
+# 1. Snapshot the current Claude data (do this before resume/compact)
+SNAP="$HOME/claude-snapshots/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$SNAP"
+cp -r ~/.config/claude/projects "$SNAP/projects"
+
+# 2. Later, run reports against the frozen snapshot
+export CLAUDE_CONFIG_DIR="$SNAP"
+better-ccusage monthly --breakdown   # totals as of the snapshot date
+```
+
+Keep snapshots around for as long as you need auditable numbers; they're plain JSONL files, so they compress well. See [#40](https://github.com/cobra91/better-ccusage/issues/40) for the original field report and repro.
+
 ## Related Documentation
 
 - [Environment Variables](/guide/environment-variables) - Configure with CLAUDE_CONFIG_DIR


### PR DESCRIPTION
Responds to the field-data point raised in [#40](https://github.com/cobra91/better-ccusage/issues/40) by @lizhuojunx86.

## Context

Claude Code rewrites session JSONL files on `resume`/`compact` and can drop earlier messages, which makes post-rewrite totals drift from actual usage (upstream bug [anthropics/claude-code#36583](https://github.com/anthropics/claude-code/issues/36583)). better-ccusage reads the files faithfully and intentionally does not reconstruct a different history (no shadow ledger).

@lizhuojunx86 pointed out that the snapshot workflow is "worth a line in the README for anyone doing billing reconciliation" — this adds it.

## Change

New section "Audit-grade reports (snapshot before resume/compact)" in `docs/guide/directory-detection.md` (the natural home: it already documents Claude's data paths and the `CLAUDE_CONFIG_DIR` override). Includes:

- One-paragraph explanation of the drift + link to the upstream bug
- Concrete snapshot + report recipe (`cp -r` then `CLAUDE_CONFIG_DIR=...$SNAP better-ccusage monthly --breakdown`)
- Link back to #40 for the original field report

No code changes. Docs lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide subsection, **“Audit-grade reports (snapshot before resume/compact)”**, explaining that session JSONL files may be rewritten/compacted during resume/compact, which can shift totals.
  * Provided step-by-step instructions to snapshot the Claude data directory (legacy and default roots), set `CLAUDE_CONFIG_DIR` to the frozen copy, and run reports (e.g., monthly breakdown) for accurate “as-of” totals.
  * Documented how to handle missing roots and noted the snapshot consists of plain JSONL files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->